### PR TITLE
alerting_burn_rate_threshold should be float

### DIFF
--- a/slo_generator/report.py
+++ b/slo_generator/report.py
@@ -77,7 +77,7 @@ class SLOReport:
                           **step,
                           lambdas={
                               'slo_target': float,
-                              'alerting_burn_rate_threshold': int
+                              'alerting_burn_rate_threshold': float
                           })
 
         # Set other fields


### PR DESCRIPTION
Currently only the int part is taken leading to false alerts.