### PR TITLE
fix: Use version 1.x.x of google-cloud-monitoring

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,10 +35,10 @@ version = "1.1.1"
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 3 - Alpha"
 dependencies = [
-    'google-api-python-client', 'oauth2client', 'google-cloud-monitoring',
-    'google-cloud-pubsub==1.7.0', 'google-cloud-bigquery',
-    'prometheus-http-client', 'prometheus-client', 'pyyaml', 'opencensus',
-    'elasticsearch', 'python-dateutil', 'datadog'
+    'google-api-python-client', 'oauth2client',
+    'google-cloud-monitoring < 2.0.0', 'google-cloud-pubsub==1.7.0',
+    'google-cloud-bigquery', 'prometheus-http-client', 'prometheus-client',
+    'pyyaml', 'opencensus', 'elasticsearch', 'python-dateutil', 'datadog'
 ]
 extras = {}
 


### PR DESCRIPTION
Version 2.0.0 update of google-cloud-monitoring breaks linting + unittests, enforcing previous one.