### PR TITLE
fix: timestamp human in UTC format

### DIFF
--- a/slo_generator/exporters/bigquery.py
+++ b/slo_generator/exporters/bigquery.py
@@ -65,6 +65,7 @@ class BigqueryExporter:
                                   data["slo_name"], data["timestamp_human"],
                                   data["window"])
         json_data = {k: v for k, v in data.items() if k in schema_fields}
+        LOGGER.debug(f'Writing data to BigQuery:\n{json_data}')
         results = self.client.insert_rows_json(
             table,
             json_rows=[json_data],
@@ -92,7 +93,7 @@ class BigqueryExporter:
         ]
 
         table_name = f"{project_id}.{dataset_id}.{table_id}"
-        LOGGER.info(f"Creating table {table_name}", table_name)
+        LOGGER.info(f"Creating table {table_name}")
         table = bigquery.Table(table_name, schema=pyschema)
         table.time_partitioning = bigquery.TimePartitioning(
             type_=bigquery.TimePartitioningType.DAY, )

--- a/slo_generator/utils.py
+++ b/slo_generator/utils.py
@@ -140,7 +140,7 @@ def get_human_time(timestamp, timezone=None):
     else:  # auto-detect locale
         to_zone = tz.tzlocal()
     dt_utc = datetime.utcfromtimestamp(timestamp)
-    dt_tz = dt_utc.astimezone(to_zone)
+    dt_tz = dt_utc.replace(tzinfo=to_zone)
     timeformat = '%Y-%m-%dT%H:%M:%S.%f%z'
     date_str = datetime.strftime(dt_tz, timeformat)
     date_str = "{0}:{1}".format(

--- a/slo_generator/utils.py
+++ b/slo_generator/utils.py
@@ -126,20 +126,27 @@ def get_human_time(timestamp, timezone=None):
         timezone (optional): Explicit timezone (e.g: "America/Chicago").
 
     Returns:
-        str: Formatted human-readable date in ISO format, localized.
+        str: Formatted human-readable date in ISO format (UTC), with
+             time zone added.
+
+    Example:
+        >>> get_human_time(1565092435, timezone='Europe/Paris')
+        >>> 2019-08-06T11:53:55.000000+02:00
+        which corresponds to the UTC time appended the timezone format
+        to help with display and retrieval of the date localized.
     """
     if timezone is not None:  # get timezone from arg
-        from_zone = tz.gettz('UTC')
         to_zone = tz.gettz(timezone)
     else:  # auto-detect locale
-        from_zone = tz.tzutc()
         to_zone = tz.tzlocal()
     dt_utc = datetime.utcfromtimestamp(timestamp)
-    dt_utc = dt_utc.replace(tzinfo=from_zone)
     dt_tz = dt_utc.astimezone(to_zone)
-    timeformat = '%Y-%m-%dT%H:%M:%S.%fZ'
-    return datetime.strftime(dt_tz, timeformat)
-
+    timeformat = '%Y-%m-%dT%H:%M:%S.%f%z'
+    date_str = datetime.strftime(dt_tz, timeformat)
+    date_str = "{0}:{1}".format(
+        date_str[:-2], date_str[-2:]
+    )
+    return date_str
 
 def normalize(path):
     """Converts a path to an absolute path.

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -21,9 +21,9 @@ from slo_generator.utils import (get_backend_cls, get_exporter_cls,
 class TestUtils(unittest.TestCase):
     def test_get_human_time(self):
         timestamp = 1565092435
-        human_time = "2019-08-06T13:53:55.000000+02:00"
+        human_time = "2019-08-06T11:53:55.000000+02:00"
         timestamp_2 = 1565095633.9568892
-        human_time_2 = "2019-08-06T14:47:13.956889+02:00"
+        human_time_2 = "2019-08-06T12:47:13.956889+02:00"
         self.assertEqual(get_human_time(timestamp, timezone='Europe/Paris'),
                          human_time)
         self.assertEqual(get_human_time(timestamp_2, timezone='Europe/Paris'),

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -20,22 +20,26 @@ from slo_generator.utils import (get_backend_cls, get_exporter_cls,
 
 class TestUtils(unittest.TestCase):
     def test_get_human_time(self):
+        # Timezones
+        tz_1 = 'Europe/Paris'
+        tz_2 = 'America/Chicago'
+
         # Timestamp 1
         timestamp = 1565092435
         utc_time = "2019-08-06T11:53:55.000000"
-        human_paris_1 = get_human_time(timestamp, timezone='Europe/Paris')
-        human_chicago_1 = get_human_time(timestamp, timezone='America/Chicago')
+        human_paris_1 = get_human_time(timestamp, timezone=tz_1)
+        human_chicago_1 = get_human_time(timestamp, timezone=tz_2)
 
         # Timestamp 2
         timestamp_2 = 1565095633.9568892
         utc_time_2 = "2019-08-06T12:47:13.956889"
-        human_paris_2 = get_human_time(timestamp, timezone='Europe/Paris')
-        human_chicago_2 = get_human_time(timestamp, timezone='America/Chicago')
+        human_paris_2 = get_human_time(timestamp_2, timezone=tz_1)
+        human_chicago_2 = get_human_time(timestamp_2, timezone=tz_2)
 
         self.assertEqual(human_paris_1, utc_time + "+02:00")
         self.assertEqual(human_chicago_1, utc_time + "-05:00")
-        self.assertEqual(human_paris_2, utc_time + "+02:00")
-        self.assertEqual(human_chicago_2, utc_time + "-05:00")
+        self.assertEqual(human_paris_2, utc_time_2 + "+02:00")
+        self.assertEqual(human_chicago_2, utc_time_2 + "-05:00")
 
     def test_get_backend_cls(self):
         res1 = get_backend_cls("Stackdriver")

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -20,14 +20,22 @@ from slo_generator.utils import (get_backend_cls, get_exporter_cls,
 
 class TestUtils(unittest.TestCase):
     def test_get_human_time(self):
+        # Timestamp 1
         timestamp = 1565092435
-        human_time = "2019-08-06T11:53:55.000000+02:00"
+        utc_time = "2019-08-06T11:53:55.000000"
+        human_paris_1 = get_human_time(timestamp, timezone='Europe/Paris')
+        human_chicago_1 = get_human_time(timestamp, timezone='America/Chicago')
+
+        # Timestamp 2
         timestamp_2 = 1565095633.9568892
-        human_time_2 = "2019-08-06T12:47:13.956889+02:00"
-        self.assertEqual(get_human_time(timestamp, timezone='Europe/Paris'),
-                         human_time)
-        self.assertEqual(get_human_time(timestamp_2, timezone='Europe/Paris'),
-                         human_time_2)
+        utc_time_2 = "2019-08-06T12:47:13.956889"
+        human_paris_2 = get_human_time(timestamp, timezone='Europe/Paris')
+        human_chicago_2 = get_human_time(timestamp, timezone='America/Chicago')
+
+        self.assertEqual(human_paris_1, utc_time + "+02:00")
+        self.assertEqual(human_chicago_1, utc_time + "-05:00")
+        self.assertEqual(human_paris_2, utc_time + "+02:00")
+        self.assertEqual(human_chicago_2, utc_time + "-05:00")
 
     def test_get_backend_cls(self):
         res1 = get_backend_cls("Stackdriver")

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -21,9 +21,9 @@ from slo_generator.utils import (get_backend_cls, get_exporter_cls,
 class TestUtils(unittest.TestCase):
     def test_get_human_time(self):
         timestamp = 1565092435
-        human_time = "2019-08-06T13:53:55.000000Z"
+        human_time = "2019-08-06T13:53:55.000000+02:00"
         timestamp_2 = 1565095633.9568892
-        human_time_2 = "2019-08-06T14:47:13.956889Z"
+        human_time_2 = "2019-08-06T14:47:13.956889+02:00"
         self.assertEqual(get_human_time(timestamp, timezone='Europe/Paris'),
                          human_time)
         self.assertEqual(get_human_time(timestamp_2, timezone='Europe/Paris'),


### PR DESCRIPTION
Decision to change the `timestamp_human` field to output standard UTC time because BigQuery and other exporters cannot make the difference. Appends timezone information if the backend can read it.