### PR TITLE
feat: add support for multiple metrics in metrics exporters

### DIFF
--- a/docs/providers/datadog.md
+++ b/docs/providers/datadog.md
@@ -120,8 +120,8 @@ exporters:
 ```
 
 Optional fields:
-  * `metric_type`: Metric type / name. Defaults to `error_budget_burn_rate`.
-  * `metric_description`: Metric description.
+  * `metrics`: List of metrics to export ([see docs](../shared/metrics.md)). Defaults to [`custom:error_budget_burn_rate`, `custom:sli_measurement`].
+
 
 **&rightarrow; [Full SLO config](../../samples/datadog/slo_dd_app_availability_ratio.yaml)**
 

--- a/docs/providers/dynatrace.md
+++ b/docs/providers/dynatrace.md
@@ -69,8 +69,7 @@ exporters:
 ```
 
 Optional fields:
-  * `metric_type`: Metric type / name. Defaults to `custom:error_budget_burn_rate`.
-  * `metric_description`: Metric description.
+  * `metrics`: List of metrics to export ([see docs](../shared/metrics.md)). Defaults to [`custom:error_budget_burn_rate`, `custom:sli_measurement`].
 
 **&rightarrow; [Full SLO config](../../samples/dynatrace/slo_dt_app_availability_ratio.yaml)**
 

--- a/docs/providers/prometheus.md
+++ b/docs/providers/prometheus.md
@@ -162,8 +162,7 @@ exporters:
 ```
 
 Optional fields:
-  * `metric_type`: Metric type / name. Defaults to `error_budget_burn_rate`.
-  * `metric_description`: Metric description.
+  * `metrics`: List of metrics to export ([see docs](../shared/metrics.md)). Defaults to [`error_budget_burn_rate`, `sli_measurement`].
   * `username`: Username for Basic Auth.
   * `password`: Password for Basic Auth.
   * `job`: Name of `Pushgateway` job. Defaults to `slo-generator`.

--- a/docs/providers/stackdriver.md
+++ b/docs/providers/stackdriver.md
@@ -105,8 +105,7 @@ exporters:
 ```
 
 Optional fields:
-* `metric_type`: Metric type / name. Defaults to `error_budget_burn_rate`.
-* `metric_description`: Metric description.
+  * `metrics`: List of metrics to export ([see docs](../shared/metrics.md)). Defaults to [`custom:error_budget_burn_rate`, `custom:sli_measurement`].
 
 **&rightarrow; [Full SLO config](../../samples/stackdriver/slo_lb_request_availability.yaml)**
 

--- a/docs/shared/metrics.md
+++ b/docs/shared/metrics.md
@@ -1,0 +1,80 @@
+# Metrics block
+
+## Configuration
+The `metrics` block can be added to the configuration of any exporter derived 
+from [`MetricsExporter`](../../slo_generator/exporters/base.py#L41). It is used 
+to specify which metrics should be exported to the destination.
+
+### Simple config
+The simple version of the `metrics` block is:
+```yaml
+metrics:
+- error_budget_burn_rate
+- sli_measurement
+- slo_target
+```
+
+### Advanced config
+The advanced format of the `metrics` block is:
+```yaml
+metrics:
+- name: error_budget_burn_rate
+  description: Error Budget burn rate.
+  alias: ebbr
+  additional_labels:
+  - good_events_count
+  - bad_events_count
+  
+- name: sli_measurement
+  description: Error Budget burn rate.
+  alias: sli
+  additional_labels:
+  - slo_target
+```
+
+where:
+* `name`: name of the [SLO Report](../../tests/unit/fixtures/slo_report.json) 
+field to export as a metric.
+* `description`: description of the metric (if the metrics exporter supports it)
+* `alias` (optional): rename the metric before writing to the monitoring 
+backend.
+* `additional_labels` (optional) allow you to specify other labels to the 
+timeseries written. Each label name must correspond to a field of the SLO 
+report.
+
+### Default (no config)
+If the `metrics` block is not present in the metrics exporter configuration, 
+the default behaviour is to export the following metrics:
+- `error_budget_burn_rate`: used for alerting.
+- `sli_measurement`: used for visualizing the SLI over time.
+
+The default set of labels added by default to each metric is:
+- `error_budget_policy_step_name`
+- `window`
+- `service_name`
+- `slo_name`
+- `alerting_burn_rate_threshold`
+
+## Metric prefix
+Some metrics exporters have a specific `prefix` that is pre-prepended to the 
+metric name:
+* `StackdriverExporter` prefix: `custom.googleapis.com/`
+* `DatadogExporter` prefix: `custom:`
+
+Those are standards and cannot be modified.
+
+**Example:**
+If the section above was added to a `StackdriverExporter`, the whole exporter
+config would look like:
+
+```yaml
+exporters:
+- class: StackdriverExporter
+    project_id: ${STACKDRIVER_PROJECT_ID}
+    metrics:
+    - name: error_budget_burn_rate
+      alias: error_budget_burn_rate
+      additional_labels:
+      - good_events_count
+      - bad_events_count   
+```

--- a/slo_generator/backends/dynatrace.py
+++ b/slo_generator/backends/dynatrace.py
@@ -206,7 +206,5 @@ class DynatraceClient:
         """
         res = resp.content.decode('utf-8').replace('\n', '')
         data = json.loads(res)
-        if 'error' in data:
-            LOGGER.error(f"Dynatrace API returned an error: {data}")
         LOGGER.debug(data)
         return data

--- a/slo_generator/exporters/base.py
+++ b/slo_generator/exporters/base.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Google Inc.
+# Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/slo_generator/exporters/base.py
+++ b/slo_generator/exporters/base.py
@@ -57,6 +57,13 @@ class MetricsExporter:
         LOGGER.info(
             f'Exporting {len(metrics)} metrics with {self.__class__.__name__}')
         for metric_cfg in metrics:
+            if isinstance(metric_cfg, str): # short form
+                metric_cfg = {
+                    'name': metric_cfg,
+                    'alias': metric_cfg,
+                    'description': "",
+                    'labels': DEFAULT_METRIC_LABELS
+                }
             metric = metric_cfg.copy()
             fields = {
                 key: value for key, value in config.items()
@@ -64,6 +71,7 @@ class MetricsExporter:
             }
             metric.update(fields)
             metric = self.build_metric(data, metric)
+            print(metric)
             LOGGER.info(f'Exporting metric: {metric}')
             self.export_metric(metric)
 

--- a/slo_generator/exporters/base.py
+++ b/slo_generator/exporters/base.py
@@ -67,7 +67,9 @@ class MetricsExporter:
                     'labels': DEFAULT_METRIC_LABELS
                 }
             if metric_cfg['name'] == 'error_budget_burn_rate':
-                metric_cfg = MetricsExporter.use_deprecated_fields(config, metric_cfg)
+                metric_cfg = MetricsExporter.use_deprecated_fields(
+                    config=config,
+                    metric=metric_cfg)
             metric = metric_cfg.copy()
             fields = {
                 key: value for key, value in config.items()

--- a/slo_generator/exporters/base.py
+++ b/slo_generator/exporters/base.py
@@ -1,0 +1,111 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#            http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+`base.py`
+Base exporter abstract classes.
+"""
+import logging
+from abc import ABCMeta, abstractmethod
+
+LOGGER = logging.getLogger(__name__)
+
+DEFAULT_METRIC_LABELS = [
+    'error_budget_policy_step_name', 'window', 'service_name', 'slo_name',
+    'alerting_burn_rate_threshold'
+]
+
+DEFAULT_METRICS = [
+    {
+        'name': 'error_budget_burn_rate',
+        'description': 'Speed at which the error budget is consumed.',
+        'labels': DEFAULT_METRIC_LABELS
+    },
+    {
+        'name': 'sli_measurement',
+        'description': 'Service Level Indicator.',
+        'labels': DEFAULT_METRIC_LABELS
+    }
+]
+
+class MetricsExporter:
+    """Abstract class to export metrics to different backends. Common format
+    for YAML configuration to configure which metrics should be exported."""
+    __metaclass__ = ABCMeta
+
+    def export(self, data, **config):
+        """Export metric data. Loops through metrics config and calls the child
+        class `export_metric` method.
+
+        Args:
+            data (dict): SLO Report data.
+            config (dict): Exporter config.
+        """
+        metrics = config.get('metrics', DEFAULT_METRICS)
+        required_fields = getattr(self, 'REQUIRED_FIELDS', [])
+        optional_fields = getattr(self, 'OPTIONAL_FIELDS', [])
+        LOGGER.info(
+            f'Exporting {len(metrics)} metrics with {self.__class__.__name__}')
+        for metric_cfg in metrics:
+            metric = metric_cfg.copy()
+            fields = {
+                key: value for key, value in config.items()
+                if key in required_fields or key in optional_fields
+            }
+            metric.update(fields)
+            metric = self.build_metric(data, metric)
+            LOGGER.info(f'Exporting metric: {metric}')
+            self.export_metric(metric)
+
+    def build_metric(self, data, metric):
+        """Build a metric from current data and metric configuration.
+        Set the metric value labels and eventual alias.
+
+        Args:
+            data (dict): SLO Report data.
+            metric (dict): Metric configuration.
+
+        Returns:
+            dict: Metric configuration.
+        """
+        name = metric['name']
+        prefix = getattr(self, 'METRIC_PREFIX', None)
+
+        # Set value + timestamp
+        metric['value'] = data[name]
+        metric['timestamp'] = data['timestamp']
+
+        # Set metric labels
+        labels = metric.get('labels', DEFAULT_METRIC_LABELS)
+        additional_labels = metric.get('additional_labels', [])
+        labels.extend(additional_labels)
+        labels = {key: str(val) for key, val in data.items() if key in labels}
+        metric['labels'] = labels
+
+        # Use metric alias (mapping)
+        if 'alias' in metric:
+            metric['name'] = metric['alias']
+
+        if prefix:
+            metric['name'] = prefix + metric['name']
+
+        # Set description
+        metric['description'] = metric.get('description', "")
+
+        return metric
+
+    @abstractmethod
+    def export_metric(self, data):
+        """Abstract method to export a metric. Should be implemented by children
+        classes."""
+        raise NotImplementedError

--- a/slo_generator/exporters/base.py
+++ b/slo_generator/exporters/base.py
@@ -141,12 +141,12 @@ class MetricsExporter:
             warnings.warn(
                 '`metric_type` will be deprecated in favor of `metrics` '
                 'in version 2.0.0, ', FutureWarning)
-        if old_metric_labels in config:
+        if old_metric_labels:
             metric['labels'] = old_metric_labels
             warnings.warn(
                 '`metric_labels` will be deprecated in favor of `metrics` '
                 'in version 2.0.0, ', FutureWarning)
-        if old_metric_description in config:
+        if old_metric_description:
             warnings.warn(
                 '`metric_description` will be deprecated in favor of `metrics` '
                 'in version 2.0.0, ', FutureWarning)

--- a/slo_generator/exporters/base.py
+++ b/slo_generator/exporters/base.py
@@ -85,7 +85,7 @@ class MetricsExporter:
             LOGGER.info(f'Exporting "{name}" ...')
             ret = self.export_metric(metric)
             metric_info = {
-                k: v for k, v in metric.items() 
+                k: v for k, v in metric.items()
                 if k in ['name', 'alias', 'description', 'labels']
             }
             response = {

--- a/slo_generator/exporters/dynatrace.py
+++ b/slo_generator/exporters/dynatrace.py
@@ -54,7 +54,7 @@ class DynatraceExporter(MetricsExporter):
         if 'error' in metric:
             LOGGER.warning("Custom metric doesn't exist. Creating it.")
             metric = self.create_custom_metric(data)
-        LOGGER.info(f'Custom metric: {metric}')
+        LOGGER.debug(f'Custom metric: {metric}')
         response = self.create_timeseries(data)
         LOGGER.debug(f'API Response: {response}')
         return response

--- a/slo_generator/exporters/prometheus.py
+++ b/slo_generator/exporters/prometheus.py
@@ -20,82 +20,60 @@ import logging
 from prometheus_client import CollectorRegistry, Gauge, push_to_gateway
 from prometheus_client.exposition import basic_auth_handler, default_handler
 
+from .base import MetricsExporter
+
 LOGGER = logging.getLogger(__name__)
-DEFAULT_METRIC_TYPE = "error_budget_burn_rate"
-DEFAULT_METRIC_DESCRIPTION = ("Speed at which the error budget for a given"
-                              "aggregation window is consumed")
-DEFAULT_PUSHGATEWAY_URL = "http://localhost:9091"
 DEFAULT_PUSHGATEWAY_JOB = "slo-generator"
 
-
-class PrometheusExporter:
+class PrometheusExporter(MetricsExporter):
     """Prometheus exporter class."""
+    REQUIRED_FIELDS = ['url']
+    OPTIONAL_FIELDS = ['job', 'username', 'password']
 
     def __init__(self):
         self.username = None
         self.password = None
 
-    def export(self, data, **config):
+    def export_metric(self, data):
         """Export data to Prometheus.
 
         Args:
-            data (dict): Data to send to Prometheus.
-            config (dict): Prometheus config.
-                url (str, optional): Prometheus URL.
-                custom_metric_type (str, optional): Custom metric type.
-                custom_metric_unit (str, optional): Custom metric unit.
-                custom_metric_description (str, optional): Custom metric
-                    description.
+            data (dict): Metric data.
 
         Returns:
             object: Prometheus API result.
         """
-        self.create_timeseries(data, **config)
+        self.create_timeseries(data)
 
-    def create_timeseries(self, data, **config):
+    def create_timeseries(self, data):
         """Create Prometheus timeseries.
 
         Args:
-            data (dict): Data to send to Prometheus.
-            config (dict): Metric / exporter config.
+            data (dict): Metric data.
 
         Returns:
             object: Metric descriptor.
         """
-        metric_type = config.get('metric_type', DEFAULT_METRIC_TYPE)
-        metric_description = config.get('metric_description',
-                                        DEFAULT_METRIC_DESCRIPTION)
-        prometheus_push_url = config.get('url', DEFAULT_PUSHGATEWAY_URL)
-        prometheus_push_job_name = config.get('job', DEFAULT_PUSHGATEWAY_JOB)
-        burn_rate = data['error_budget_burn_rate']
+        name = data['name']
+        description = data['description']
+        prometheus_push_url = data['url']
+        prometheus_push_job_name = data.get('job', DEFAULT_PUSHGATEWAY_JOB)
+        value = data['value']
 
         # Write timeseries w/ metric labels.
-        labels = {
-            'service_name':
-                data['service_name'],
-            'feature_name':
-                data['feature_name'],
-            'slo_name':
-                data['slo_name'],
-            'window':
-                str(data['window']),
-            'error_budget_policy_step_name':
-                str(data['error_budget_policy_step_name']),
-            'alerting_burn_rate_threshold':
-                str(data['alerting_burn_rate_threshold']),
-        }
+        labels = data['labels']
         registry = CollectorRegistry()
-        gauge = Gauge(metric_type,
-                      metric_description,
+        gauge = Gauge(name,
+                      description,
                       registry=registry,
                       labelnames=labels.keys())
-        gauge.labels(*labels.values()).set(burn_rate)
+        gauge.labels(*labels.values()).set(value)
 
         # Handle headers
         handler = default_handler
-        if 'username' in config and 'password' in config:
-            self.username = config['username']
-            self.password = config['password']
+        if 'username' in data and 'password' in data:
+            self.username = data['username']
+            self.password = data['password']
             handler = PrometheusExporter.auth_handler
 
         return push_to_gateway(prometheus_push_url,

--- a/tests/unit/fixtures/exporters.yaml
+++ b/tests/unit/fixtures/exporters.yaml
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+---
   - class:      Pubsub
     project_id: ${PUBSUB_PROJECT_ID}
     topic_name: ${PUBSUB_TOPIC_NAME}
@@ -33,3 +34,12 @@
   - class:      Dynatrace
     api_url:    ${DYNATRACE_API_URL}
     api_token:  ${DYNATRACE_API_TOKEN}
+
+  # Old format that will be deprecated in 2.0.0 in favor of the `metrics` block
+  - class: Stackdriver
+    project_id: ${STACKDRIVER_HOST_PROJECT_ID}
+    metric_type: custom.googleapis.com/ebp
+    metric_description: Test old format
+    metric_labels: [good_events_count, bad_events_count]
+    metrics:
+      - error_budget_burn_rate

--- a/tests/unit/test_compute.py
+++ b/tests/unit/test_compute.py
@@ -152,6 +152,12 @@ class TestCompute(unittest.TestCase):
     def test_export_dynatrace(self, mock):
         export(SLO_REPORT, EXPORTERS[5])
 
+    @patch("google.api_core.grpc_helpers.create_channel",
+           return_value=mock_sd(STEPS))
+    def test_export_deprecated(self, mock):
+        with self.assertWarns(FutureWarning):
+            export(SLO_REPORT, EXPORTERS[6])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add support to export multiple metrics with metrics exporters:
- [x] Add config blob to specify custom metric configuration
- [x] Add ABC meta class `MetricsExporter` to inherit from - will handle all operations shared by metrics exporters
- [x] Add documentation for the `metrics` configuration blob
- [x] Add unittest for `metrics` configuration blob