### PR TITLE
fix: Datadog count

### DIFF
--- a/slo_generator/backends/datadog.py
+++ b/slo_generator/backends/datadog.py
@@ -176,7 +176,7 @@ class DatadogBackend:
                 values.append(value)
             if not values:
                 raise IndexError
-            return sum(values) / len(values)
+            return sum(values)
         except (IndexError, AttributeError) as exception:
             LOGGER.warning("Couldn't find any values in timeseries response")
             LOGGER.debug(exception)

--- a/slo_generator/backends/datadog.py
+++ b/slo_generator/backends/datadog.py
@@ -157,8 +157,7 @@ class DatadogBackend:
 
     @staticmethod
     def count(timeseries):
-        """Count events in time series. If multiple values are returned, take
-        the average of all values.
+        """Count events in time series.
 
         Args:
             :dict: Timeseries response from Datadog Metrics API endpoint.


### PR DESCRIPTION
Averaging on all values for `count` method does not return accurate good / bad values. This fixes it.