### PR TITLE
feat: Add custom metadata to SLO configs

### DIFF
--- a/slo_generator/constants.py
+++ b/slo_generator/constants.py
@@ -20,3 +20,4 @@ import os
 NO_DATA = -1
 MIN_VALID_EVENTS = int(os.environ.get("MIN_VALID_EVENTS", "1"))
 COLORED_OUTPUT = int(os.environ.get("COLORED_OUTPUT", "0"))
+DRY_RUN = bool(int(os.environ.get("DRY_RUN", "0")))

--- a/slo_generator/exporters/base.py
+++ b/slo_generator/exporters/base.py
@@ -23,7 +23,7 @@ LOGGER = logging.getLogger(__name__)
 
 DEFAULT_METRIC_LABELS = [
     'error_budget_policy_step_name', 'window', 'service_name', 'feature_name',
-    'slo_name', 'alerting_burn_rate_threshold'
+    'slo_name', 'alerting_burn_rate_threshold', 'metadata'
 ]
 
 DEFAULT_METRICS = [
@@ -130,26 +130,11 @@ class MetricsExporter:
         metric['value'] = data[name]
         metric['timestamp'] = data['timestamp']
 
-        # Set metric labels
+        # Set metric data labels
         labels = metric.get('labels', DEFAULT_METRIC_LABELS)
         additional_labels = metric.get('additional_labels', [])
-
-        # Data labels (using pre-defined labels, defined by str)
-        data_labels = [
-            label for label in additional_labels
-            if isinstance(label, str)]
-        labels.extend(data_labels)
-        labels = {key: str(val) for key, val in data.items() if key in labels}
-
-        # User labels (set explicitely by user, defined by dict)
-        user_labels = [
-            label for label in additional_labels
-            if isinstance(label, dict)
-        ]
-        for label in user_labels:
-            labels.update({label['key']: label['value']})
-
-        # Set metric labels
+        labels.extend(additional_labels)
+        labels = MetricsExporter.build_data_labels(data, labels)
         metric['labels'] = labels
 
         # Use metric alias (mapping)
@@ -163,6 +148,33 @@ class MetricsExporter:
         metric['description'] = metric.get('description', "")
 
         return metric
+
+    @staticmethod
+    def build_data_labels(data, labels):
+        """Build data labels. Also handle nested labels (depth=1).
+
+        Args:
+            data (dict): SLO Report data.
+            labels (list): Label keys.
+
+        Returns:
+            dict: Data labels.
+        """
+        data_labels = {}
+        nested_labels = [
+            label for label in labels
+            if isinstance(data[label], dict)
+        ]
+        flat_labels = [
+            label for label in labels
+            if label in data and not isinstance(data[label], dict)
+        ]
+        for label in nested_labels:
+            data_labels.update({k: str(v) for k, v in data[label].items()})
+        for label in flat_labels:
+            data_labels.update({label: str(data[label])})
+        LOGGER.debug(f'Data labels: {data_labels}')
+        return data_labels
 
     @staticmethod
     def use_deprecated_fields(config, metric):

--- a/slo_generator/exporters/base.py
+++ b/slo_generator/exporters/base.py
@@ -163,7 +163,7 @@ class MetricsExporter:
         data_labels = {}
         nested_labels = [
             label for label in labels
-            if isinstance(data[label], dict)
+            if label in data and isinstance(data[label], dict)
         ]
         flat_labels = [
             label for label in labels

--- a/slo_generator/exporters/base.py
+++ b/slo_generator/exporters/base.py
@@ -133,8 +133,23 @@ class MetricsExporter:
         # Set metric labels
         labels = metric.get('labels', DEFAULT_METRIC_LABELS)
         additional_labels = metric.get('additional_labels', [])
-        labels.extend(additional_labels)
+
+        # Data labels (using pre-defined labels, defined by str)
+        data_labels = [
+            label for label in additional_labels
+            if isinstance(label, str)]
+        labels.extend(data_labels)
         labels = {key: str(val) for key, val in data.items() if key in labels}
+
+        # User labels (set explicitely by user, defined by dict)
+        user_labels = [
+            label for label in additional_labels
+            if isinstance(label, dict)
+        ]
+        for label in user_labels:
+            labels.update({label['key']: label['value']})
+
+        # Set metric labels
         metric['labels'] = labels
 
         # Use metric alias (mapping)

--- a/slo_generator/report.py
+++ b/slo_generator/report.py
@@ -17,7 +17,7 @@ Report utilities.
 """
 
 import logging
-from dataclasses import asdict, dataclass, fields
+from dataclasses import asdict, dataclass, fields, field
 
 from slo_generator import utils
 from slo_generator.constants import COLORED_OUTPUT, MIN_VALID_EVENTS, NO_DATA
@@ -38,6 +38,9 @@ class SLOReport:
         delete (bool): Backend delete action.
     """
     # pylint: disable=too-many-instance-attributes
+
+    # Metadata
+    metadata: dict = field(default_factory=dict)
 
     # SLO
     service_name: str
@@ -80,12 +83,12 @@ class SLOReport:
                               'slo_target': float,
                               'alerting_burn_rate_threshold': float
                           })
-
         # Set other fields
         self.window = int(step['measurement_window_seconds'])
         self.timestamp = int(timestamp)
         self.timestamp_human = utils.get_human_time(timestamp)
         self.valid = True
+        self.metadata = config.get('metadata', {})
 
         # Get backend results
         data = self.run_backend(config, client=client, delete=delete)

--- a/tests/unit/fixtures/exporters.yaml
+++ b/tests/unit/fixtures/exporters.yaml
@@ -53,6 +53,3 @@
           # data labels
           - good_events_count
           - bad_events_count
-          # user labels
-          - key: test
-            value: test

--- a/tests/unit/fixtures/exporters.yaml
+++ b/tests/unit/fixtures/exporters.yaml
@@ -43,3 +43,16 @@
     metric_labels: [good_events_count, bad_events_count]
     metrics:
       - error_budget_burn_rate
+
+  # New format ('metrics' block)
+  - class: Stackdriver
+    project_id: ${STACKDRIVER_HOST_PROJECT_ID}
+    metrics:
+      - name: error_budget_burn_rate
+        additional_labels:
+          # data labels
+          - good_events_count
+          - bad_events_count
+          # user labels
+          - key: test
+            value: test

--- a/tests/unit/fixtures/slo_report.json
+++ b/tests/unit/fixtures/slo_report.json
@@ -22,5 +22,9 @@
   "error_budget_measurement": 0.5,
   "error_budget_burn_rate": 5.000000000000001,
   "alerting_burn_rate_threshold": 3.0,
-  "alert": "true"
+  "alert": "true",
+  "metadata": {
+    "env": "test",
+    "team": "test"
+  }
 }

--- a/tests/unit/test_compute.py
+++ b/tests/unit/test_compute.py
@@ -23,7 +23,7 @@ from prometheus_http_client import Prometheus
 from slo_generator.backends.dynatrace import DynatraceClient
 from slo_generator.compute import compute, export
 from slo_generator.exporters.bigquery import BigQueryError
-
+from slo_generator.exporters.base import MetricsExporter, DEFAULT_METRIC_LABELS
 from .test_stubs import (CTX, load_fixture, load_sample, load_slo_samples,
                          mock_dd_metric_query, mock_dd_metric_send,
                          mock_dd_slo_get, mock_dd_slo_history,
@@ -167,8 +167,6 @@ class TestCompute(unittest.TestCase):
             export(SLO_REPORT, EXPORTERS[6])
 
     def test_build_metrics(self):
-        from slo_generator.exporters.base import (
-            MetricsExporter, DEFAULT_METRIC_LABELS)
         exporter = MetricsExporter()
         metric = EXPORTERS[7]['metrics'][0]
         labels = {

--- a/tests/unit/test_compute.py
+++ b/tests/unit/test_compute.py
@@ -196,7 +196,7 @@ class TestCompute(unittest.TestCase):
         }
         metric = exporter.build_metric(data=SLO_REPORT, metric=metric)
         self.assertEqual(labels, metric['labels'])
-        # self.assertEqual(metric, metric_expected)
+        self.assertEqual(metric, metric_expected)
 
     def test_build_data_labels(self):
         exporter = MetricsExporter()

--- a/tests/unit/test_compute.py
+++ b/tests/unit/test_compute.py
@@ -190,8 +190,6 @@ class TestCompute(unittest.TestCase):
             'additional_labels': metric['additional_labels']
         }
         metric = exporter.build_metric(data=SLO_REPORT, metric=metric)
-        print(metric)
-        print(metric_expected)
         self.assertEqual(metric, metric_expected)
 
 

--- a/tests/unit/test_compute.py
+++ b/tests/unit/test_compute.py
@@ -60,6 +60,7 @@ SSM_MOCKS = [
 
 class TestCompute(unittest.TestCase):
     maxDiff = None
+
     @patch('google.api_core.grpc_helpers.create_channel',
            return_value=mock_sd(2 * STEPS * len(SLO_CONFIGS_SD)))
     def test_compute_stackdriver(self, mock):


### PR DESCRIPTION
This PR does the following:
- [x] New `metadata` field that can be specified in the SLO Config JSON
- [x] New `DRY_RUN` environment variable to use globally
- [x] `BigqueryExporter` - ability to export `metadata`:
  - [x] Updates the BQ exporter schema to account for `metadata` field
  - [x] Adds `update_schema` method to auto-migrate the BQ schema if it has changed
  - [x] Adds `keep_fields` to keep fields defined outside the `slo-generator` schema (e.g: manually updated table schemas)
  - [x] Adds "dry run" mode, to run before actually updating the BQ schema
- [x] `MetricsExporter` - ability to export `metadata` as flattened metrics labels
  - [x] Add `metadata` to default exported labels
  - [x] Add `build_data_labels` method to handle nested metadata

Fixes #102 