### PR TITLE
Fix metrics exporter

### DIFF
--- a/docs/shared/metrics.md
+++ b/docs/shared/metrics.md
@@ -82,14 +82,4 @@ Some metrics exporters have a limit of `labels` that can be written to their
 metrics timeseries:
 * `StackdriverExporter` labels limit: `10`.
 
-  You might run into the following error if you have too many labels:
-  ```
-  The new labels would cause the metric custom.googleapis.com/slo_target to have over 10 labels.: timeSeries[0]"
-        debug_error_string = "{"created":"@1605001943.853828000","description":"Error received from peer ipv6:[2a00:1450:4007:817::200a]:443","file":"src/core/lib/surface/call.cc","file_line":1062,"grpc_message":"One or more TimeSeries could not be written: The new labels would cause the metric custom.googleapis.com/slo_target to have over 10 labels.: timeSeries[0]","grpc_status":3}"
-  ```
-
-  A solution is to delete de metric descriptor (will delete historical data for 
-  the metric) and re-run. You can do so using `gmon` (`pip install gmon`) and 
-  run: `gmon metrics delete custom.googleapis.com/slo_target`.
-
 Those are standards and cannot be modified.

--- a/docs/shared/metrics.md
+++ b/docs/shared/metrics.md
@@ -5,8 +5,33 @@ The `metrics` block can be added to the configuration of any exporter derived
 from [`MetricsExporter`](../../slo_generator/exporters/base.py#L41). It is used 
 to specify which metrics should be exported to the destination.
 
-### Simple config
-The simple version of the `metrics` block is:
+**Metrics** exported by default:
+- `error_budget_burn_rate`: used for alerting.
+- `alerting_burn_rate_threshold`: used for defining the alerting threshold.
+- `sli_measurement`: used for visualizing the SLI over time.
+- `slo_target`: used for drawing target over SLI measurement.
+- `events_count`: used to split good / bad events in dashboards. Has two 
+additional labels: `good_events_count` and `bad_events_count`.
+
+**Metric labels** exported by default:
+- `service_name`
+- `feature_name`
+- `slo_name`
+- `error_budget_policy_step_name`
+- `metadata` labels, flattened, coming from the SLO configuration.
+  For instance, if the SLO config contains the following metadata:
+  ```yaml
+  metadata:
+    env: dev
+    team: devrel
+    site: us
+  ```
+  The `env`, `team`, and `site` label will be available in the exported metric
+  automatically.
+
+### Override config (simple)
+If you want to discard some default metrics, but keep the overall defaults, you 
+can use the simple override of the `metrics` block:
 ```yaml
 metrics:
 - error_budget_burn_rate
@@ -14,19 +39,24 @@ metrics:
 - slo_target
 ```
 
-### Advanced config
-The advanced format of the `metrics` block is:
+### Override config (advanced)
+If you want to discard some default metrics while having additional settings,
+you can use the advanced override of the `metrics` block:
 ```yaml
 metrics:
 - name: error_budget_burn_rate
   description: Error Budget burn rate.
   alias: ebbr
+
+- name: events_count
+  description: Events count.
+  alias: events
   additional_labels:
   - good_events_count
   - bad_events_count
   
 - name: sli_measurement
-  description: Error Budget burn rate.
+  description: SLI measurement.
   alias: sli
   additional_labels:
   - slo_target
@@ -34,36 +64,32 @@ metrics:
 
 where:
 * `name`: name of the [SLO Report](../../tests/unit/fixtures/slo_report.json) 
-field to export as a metric.
+field to export as a metric. The field MUST exist in the SLO report.
 * `description`: description of the metric (if the metrics exporter supports it)
 * `alias` (optional): rename the metric before writing to the monitoring 
 backend.
 * `additional_labels` (optional) allow you to specify other labels to the 
-timeseries written. Each label name must correspond to a field of the SLO 
-report.
+timeseries written. Each label name must correspond to a field of the 
+[SLO Report](../../tests/unit/fixtures/slo_report.json).
 
-### Default (no config)
-If the `metrics` block is not present in the metrics exporter configuration, 
-the default behaviour is to export the following metrics:
-- `error_budget_burn_rate`: used for alerting.
-- `sli_measurement`: used for visualizing the SLI over time.
-
-The default set of labels added by default to each metric is:
-- `error_budget_policy_step_name`
-- `window`
-- `service_name`
-- `slo_name`
-- `alerting_burn_rate_threshold`
-
-## Metric prefix
+## Metric exporters
 Some metrics exporters have a specific `prefix` that is pre-prepended to the 
 metric name:
 * `StackdriverExporter` prefix: `custom.googleapis.com/`
 * `DatadogExporter` prefix: `custom:`
 
+Some metrics exporters have a limit of `labels` that can be written to their 
+metrics timeseries:
+* `StackdriverExporter` labels limit: `10`.
+
+  You might run into the following error if you have too many labels:
+  ```
+  The new labels would cause the metric custom.googleapis.com/slo_target to have over 10 labels.: timeSeries[0]"
+        debug_error_string = "{"created":"@1605001943.853828000","description":"Error received from peer ipv6:[2a00:1450:4007:817::200a]:443","file":"src/core/lib/surface/call.cc","file_line":1062,"grpc_message":"One or more TimeSeries could not be written: The new labels would cause the metric custom.googleapis.com/slo_target to have over 10 labels.: timeSeries[0]","grpc_status":3}"
+  ```
+
+  A solution is to delete de metric descriptor (will delete historical data for 
+  the metric) and re-run. You can do so using `gmon` (`pip install gmon`) and 
+  run: `gmon metrics delete custom.googleapis.com/slo_target`.
+
 Those are standards and cannot be modified.
-
-## MetricsExporter
-
-The `MetricsExporter` base class that other exporters can inherit from has the 
-following behavior:

--- a/docs/shared/troubleshooting.md
+++ b/docs/shared/troubleshooting.md
@@ -1,0 +1,22 @@
+# Troubleshooting
+
+## `StackdriverExporter`: Labels limit (10) reached.
+```
+The new labels would cause the metric custom.googleapis.com/slo_target to have over 10 labels.: timeSeries[0]"
+    debug_error_string = "{"created":"@1605001943.853828000","description":"Error received from peer ipv6:[2a00:1450:4007:817::200a]:443","file":"src/core/lib/surface/call.cc","file_line":1062,"grpc_message":"One or more TimeSeries could not be written: The new labels would cause the metric custom.googleapis.com/slo_target to have over 10 labels.: timeSeries[0]","grpc_status":3}"
+```
+
+### Solutions
+
+**Solution 1:**
+Delete the metric descriptor, and re-run the SLO Generator. 
+You can do so using `gmon` (`pip install gmon`) and run: 
+`gmon metrics delete custom.googleapis.com/slo_target`.
+**Warning:** this will destroy all historical metric data (6 weeks). 
+If you are using the metric in Cloud Monitoring dashboards, be wary.
+
+**Solution 2:**
+Limit the number of user labels sent with the metric.
+The default metrics are exported with 7 labels maximum, which means you have up 
+to 3 additional user labels (`metadata` labels in SLO config, or 
+`additional_labels` in the `metrics` config).

--- a/docs/shared/troubleshooting.md
+++ b/docs/shared/troubleshooting.md
@@ -1,6 +1,9 @@
 # Troubleshooting
 
-## `StackdriverExporter`: Labels limit (10) reached.
+## Problem
+
+**`StackdriverExporter`: Labels limit (10) reached.**
+
 ```
 The new labels would cause the metric custom.googleapis.com/slo_target to have over 10 labels.: timeSeries[0]"
     debug_error_string = "{"created":"@1605001943.853828000","description":"Error received from peer ipv6:[2a00:1450:4007:817::200a]:443","file":"src/core/lib/surface/call.cc","file_line":1062,"grpc_message":"One or more TimeSeries could not be written: The new labels would cause the metric custom.googleapis.com/slo_target to have over 10 labels.: timeSeries[0]","grpc_status":3}"
@@ -11,7 +14,7 @@ The new labels would cause the metric custom.googleapis.com/slo_target to have o
 **Solution 1:**
 Delete the metric descriptor, and re-run the SLO Generator. 
 You can do so using `gmon` (`pip install gmon`) and run: 
-`gmon metrics delete custom.googleapis.com/slo_target`.
+`gmon metrics delete custom.googleapis.com/slo_target -p <SD_HOST_PROJECT_ID>`.
 **Warning:** this will destroy all historical metric data (6 weeks). 
 If you are using the metric in Cloud Monitoring dashboards, be wary.
 

--- a/samples/prometheus/slo_prom_metrics_latency_distribution_cut.yaml
+++ b/samples/prometheus/slo_prom_metrics_latency_distribution_cut.yaml
@@ -12,22 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-service_name:             prom
-feature_name:             metrics
-slo_description:          99.99% of Prometheus requests return in less than 250ms
-slo_name:                 latency
-slo_target:               0.9999
+service_name:         prom
+feature_name:         metrics
+slo_description:      99.99% of Prometheus requests return in less than 250ms
+slo_name:             latency
+slo_target:           0.9999
 backend:
-  class:                  Prometheus
-  url:                    ${PROMETHEUS_URL}
-  method:                 distribution_cut
+  class:              Prometheus
+  url:                ${PROMETHEUS_URL}
+  method:             distribution_cut
   measurement:
-    expression:           http_request_duration_seconds_bucket{handler="/metrics", code=~"2.."}
-    threshold_bucket:     0.25 # in seconds, corresponds to the `le` (less than) PromQL label
+    expression:       http_request_duration_seconds_bucket{handler="/metrics", code=~"2.."}
+    threshold_bucket: 0.25 # in seconds, corresponds to the `le` (less than) PromQL label
 exporters:
-  - class:                Bigquery
-    project_id:           rnm-shared-monitoring
-    dataset_id:           slos
-    table_id:             reports
-  - class:                Stackdriver
-    project_id:           rnm-shared-monitoring
+- class:              Prometheus
+  url:                ${PROMETHEUS_PUSHGATEWAY_URL}

--- a/slo_generator/exporters/base.py
+++ b/slo_generator/exporters/base.py
@@ -22,8 +22,8 @@ from abc import ABCMeta, abstractmethod
 LOGGER = logging.getLogger(__name__)
 
 DEFAULT_METRIC_LABELS = [
-    'error_budget_policy_step_name', 'window', 'service_name', 'feature_name',
-    'slo_name', 'alerting_burn_rate_threshold', 'metadata'
+    'error_budget_policy_step_name', 'service_name', 'feature_name', 'slo_name',
+    'metadata'
 ]
 
 DEFAULT_METRICS = [
@@ -98,7 +98,10 @@ class MetricsExporter:
             metric = self.build_metric(data, metric)
             name = metric['name']
             labels = metric['labels']
-            LOGGER.info(f'Exporting "{name}" with labels {labels}...')
+            labels_str = ', '.join([f'{k}={v}' for k, v in labels.items()])
+            LOGGER.info(
+                f'Exporting "{name}" with {len(labels.keys())} labels: '
+                f'{labels_str}...')
             ret = self.export_metric(metric)
             metric_info = {
                 k: v for k, v in metric.items()
@@ -132,7 +135,7 @@ class MetricsExporter:
         metric['timestamp'] = data['timestamp']
 
         # Set metric data labels
-        labels = metric.get('labels', DEFAULT_METRIC_LABELS)
+        labels = metric.get('labels', DEFAULT_METRIC_LABELS).copy()
         additional_labels = metric.get('additional_labels', [])
         labels.extend(additional_labels)
         labels = MetricsExporter.build_data_labels(data, labels)
@@ -147,7 +150,6 @@ class MetricsExporter:
 
         # Set description
         metric['description'] = metric.get('description', "")
-
         return metric
 
     @staticmethod

--- a/slo_generator/utils.py
+++ b/slo_generator/utils.py
@@ -228,7 +228,7 @@ def import_dynamic(package, name, prefix="class"):
             f'package and class name are valid, or that importing it doesn\'t '
             f'result in an exception.')
         LOGGER.debug(exception, exc_info=True)
-        sys.exit(1)
+        raise exception
 
 
 def dict_snake_to_caml(data):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -48,14 +48,14 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(res1.__module__, "slo_generator.backends.stackdriver")
         self.assertEqual(res2.__name__, "PrometheusBackend")
         self.assertEqual(res2.__module__, "slo_generator.backends.prometheus")
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ModuleNotFoundError):
             get_backend_cls("UndefinedBackend")
 
     def test_get_backend_dynamic_cls(self):
         res1 = get_backend_cls("pathlib.Path")
         self.assertEqual(res1.__name__, "Path")
         self.assertEqual(res1.__module__, "pathlib")
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ModuleNotFoundError):
             get_exporter_cls("foo.bar.DoesNotExist")
 
     def test_get_exporter_cls(self):
@@ -68,14 +68,14 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(res2.__module__, "slo_generator.exporters.pubsub")
         self.assertEqual(res3.__name__, "BigqueryExporter")
         self.assertEqual(res3.__module__, "slo_generator.exporters.bigquery")
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ModuleNotFoundError):
             get_exporter_cls("UndefinedExporter")
 
     def test_get_exporter_dynamic_cls(self):
         res1 = get_exporter_cls("pathlib.Path")
         self.assertEqual(res1.__name__, "Path")
         self.assertEqual(res1.__module__, "pathlib")
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ModuleNotFoundError):
             get_exporter_cls("foo.bar.DoesNotExist")
 
     def test_import_dynamic(self):
@@ -87,7 +87,7 @@ class TestUtils(unittest.TestCase):
                               prefix="exporter")
         self.assertEqual(res1.__name__, "StackdriverBackend")
         self.assertEqual(res2.__name__, "StackdriverExporter")
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ModuleNotFoundError):
             import_dynamic("slo_generator.backends.unknown",
                            "StackdriverUnknown",
                            prefix="unknown")


### PR DESCRIPTION
This PR:
- [x] Fixes export when using multiple exporters - labels are not modified anymore from one exporter instance to the other
- [x] Adds safeguard for exporters (try / except) + unittests
- [x] Adds troubleshooting steps
- [x] Update documentation for metrics exporters
- [x] Add `raise_on_error` to `export` method