### PR TITLE
chore: replace PUT by POST for prometheus exporter (push-gateway)

### DIFF
--- a/slo_generator/exporters/prometheus.py
+++ b/slo_generator/exporters/prometheus.py
@@ -77,10 +77,10 @@ class PrometheusExporter(MetricsExporter):
             handler = PrometheusExporter.auth_handler
 
         return pushadd_to_gateway(prometheus_push_url,
-                               job=prometheus_push_job_name,
-                               grouping_key=labels,
-                               registry=registry,
-                               handler=handler)
+                                  job=prometheus_push_job_name,
+                                  grouping_key=labels,
+                                  registry=registry,
+                                  handler=handler)
 
     def auth_handler(self, url, method, timeout, headers, data):
         """Handles authentication for pushing to Prometheus gateway.

--- a/slo_generator/exporters/prometheus.py
+++ b/slo_generator/exporters/prometheus.py
@@ -17,7 +17,7 @@ Stackdriver Monitoring exporter class.
 """
 import logging
 
-from prometheus_client import CollectorRegistry, Gauge, push_to_gateway
+from prometheus_client import CollectorRegistry, Gauge, pushadd_to_gateway
 from prometheus_client.exposition import basic_auth_handler, default_handler
 
 from .base import MetricsExporter
@@ -76,7 +76,7 @@ class PrometheusExporter(MetricsExporter):
             self.password = data['password']
             handler = PrometheusExporter.auth_handler
 
-        return push_to_gateway(prometheus_push_url,
+        return pushadd_to_gateway(prometheus_push_url,
                                job=prometheus_push_job_name,
                                grouping_key=labels,
                                registry=registry,


### PR DESCRIPTION
When using the prometheus exporter, metrics _with the same labels_ get overwritten, resulting in persisting a single metric (out of the 4 intended).

As per [pushgateway](https://github.com/prometheus/pushgateway#exposed-metrics) :

> PUT is used to push a group of metrics. All metrics with the grouping key specified in the URL are replaced by the metrics pushed with PUT. 

Using POST with [pushadd_to_gateway](https://github.com/prometheus/client_python/blob/master/prometheus_client/exposition.py#L311) instead of [push_to_gateway](https://github.com/prometheus/client_python/blob/master/prometheus_client/exposition.py#L285) addresses this.