### PR TITLE
fix: Error when running python setup.py install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,10 +63,10 @@ install_twine:
 	$(PIP) install twine
 
 develop:
-	$(PYTHON) setup.py develop
+	$(PIP) install -e .
 
 install: clean
-	$(PYTHON) setup.py install
+	$(PIP) install .
 
 install_test:
 	$(PIP) install wheel flake8 mock coverage nose pylint

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ https://github.com/pypa/sampleproject
 
 from io import open
 from os import path
+import sys
 
 from setuptools import find_packages, setup
 
@@ -47,6 +48,7 @@ extras = {}
 with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
+sys.dont_write_bytecode = True
 setup(name=name,
       version=version,
       description=description,


### PR DESCRIPTION
Seems like setuptools is broken on all CI tests. Replacing `python setup.py install` with `pip install .` works well. Not sure why ..