### PR TITLE
feat!: Support slo-generator config v2 format (core changes)

### DIFF
--- a/slo_generator/backends/cloud_monitoring.py
+++ b/slo_generator/backends/cloud_monitoring.py
@@ -81,7 +81,8 @@ class CloudMonitoringBackend:
             valid_ts = list(valid_ts)
             bad_event_count = CM.count(valid_ts) - good_event_count
         else:
-            raise Exception("Oneof `filter_bad` or `filter_valid` is required.")
+            raise Exception(
+                "One of `filter_bad` or `filter_valid` is required.")
 
         LOGGER.debug(f'Good events: {good_event_count} | '
                      f'Bad events: {bad_event_count}')

--- a/slo_generator/backends/cloud_monitoring.py
+++ b/slo_generator/backends/cloud_monitoring.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-`stackdriver.py`
-Stackdriver Monitoring backend implementation.
+`cloud_monitoring.py`
+Cloud Monitoring backend implementation.
 """
 import logging
 import pprint
@@ -27,15 +27,16 @@ from slo_generator.constants import NO_DATA
 LOGGER = logging.getLogger(__name__)
 
 
-class StackdriverBackend:
-    """Backend for querying metrics from Stackdriver Monitoring.
+class CloudMonitoringBackend:
+    """Backend for querying metrics from Cloud Monitoring.
 
     Args:
-        project_id (str): Stackdriver host project id.
+        project_id (str): Cloud Monitoring host project id.
         client (google.cloud.monitoring_v3.MetricServiceClient, optional):
-            Existing Stackdriver Service Monitoring client. Initialize a new
-            client if omitted.
+            Existing Cloud Monitoring Metrics client. Initialize a new client
+            if omitted.
     """
+
     def __init__(self, project_id, client=None):
         self.client = client
         if client is None:
@@ -54,8 +55,7 @@ class StackdriverBackend:
         Returns:
             tuple: A tuple (good_event_count, bad_event_count)
         """
-        conf = slo_config['backend']
-        measurement = conf['measurement']
+        measurement = slo_config['spec']['service_level_indicator']
         filter_good = measurement['filter_good']
         filter_bad = measurement.get('filter_bad')
         filter_valid = measurement.get('filter_valid')
@@ -65,7 +65,7 @@ class StackdriverBackend:
                              window=window,
                              filter=filter_good)
         good_ts = list(good_ts)
-        good_event_count = SD.count(good_ts)
+        good_event_count = CM.count(good_ts)
 
         # Query 'bad events' timeseries
         if filter_bad:
@@ -73,16 +73,15 @@ class StackdriverBackend:
                                 window=window,
                                 filter=filter_bad)
             bad_ts = list(bad_ts)
-            bad_event_count = SD.count(bad_ts)
+            bad_event_count = CM.count(bad_ts)
         elif filter_valid:
             valid_ts = self.query(timestamp=timestamp,
                                   window=window,
                                   filter=filter_valid)
             valid_ts = list(valid_ts)
-            bad_event_count = SD.count(valid_ts) - good_event_count
+            bad_event_count = CM.count(valid_ts) - good_event_count
         else:
-            raise Exception(
-                "Oneof `filter_bad` or `filter_valid` is required.")
+            raise Exception("Oneof `filter_bad` or `filter_valid` is required.")
 
         LOGGER.debug(f'Good events: {good_event_count} | '
                      f'Bad events: {bad_event_count}')
@@ -100,8 +99,7 @@ class StackdriverBackend:
         Returns:
             tuple: A tuple (good_event_count, bad_event_count).
         """
-        conf = slo_config['backend']
-        measurement = conf['measurement']
+        measurement = slo_config['spec']['service_level_indicator']
         filter_valid = measurement['filter_valid']
         threshold_bucket = int(measurement['threshold_bucket'])
         good_below_threshold = measurement.get('good_below_threshold', True)
@@ -168,7 +166,7 @@ class StackdriverBackend:
               aligner='ALIGN_SUM',
               reducer='REDUCE_SUM',
               group_by=[]):
-        """Query timeseries from Stackdriver Monitoring.
+        """Query timeseries from Cloud Monitoring.
 
         Args:
             timestamp (int): Current timestamp.
@@ -181,8 +179,8 @@ class StackdriverBackend:
         Returns:
             list: List of timeseries objects.
         """
-        measurement_window = SD.get_window(timestamp, window)
-        aggregation = SD.get_aggregation(window,
+        measurement_window = CM.get_window(timestamp, window)
+        aggregation = CM.get_aggregation(window,
                                          aligner=aligner,
                                          reducer=reducer,
                                          group_by=group_by)
@@ -261,4 +259,4 @@ class StackdriverBackend:
         return aggregation
 
 
-SD = StackdriverBackend
+CM = CloudMonitoringBackend

--- a/slo_generator/backends/cloud_service_monitoring.py
+++ b/slo_generator/backends/cloud_service_monitoring.py
@@ -34,7 +34,7 @@ LOGGER = logging.getLogger(__name__)
 SID_GAE = 'gae:{project_id}_{module_id}'
 SID_CLOUD_ENDPOINT = 'ist:{project_id}-{service}'
 SID_CLUSTER_ISTIO = (
-    'ist:{project_id}-zone-{location}-{cluster_name}-{service_namespace}-'
+    'ist:{project_id}-{suffix}-{location}-{cluster_name}-{service_namespace}-'
     '{service_name}')
 SID_MESH_ISTIO = ('ist:{mesh_uid}-{service_namespace}-{service_name}')
 
@@ -290,6 +290,11 @@ class CloudServiceMonitoringBackend:
                 'ClusterIstio is deprecated in the Service Monitoring API.'
                 'It will be removed in version 3.0, please use MeshIstio '
                 'instead', FutureWarning)
+            if 'location' in cluster_istio:
+                cluster_istio['suffix'] = 'location'
+            elif 'zone' in cluster_istio:
+                cluster_istio['suffix'] = 'zone'
+                cluster_istio['location'] = cluster_istio['zone']
             service_id = SID_CLUSTER_ISTIO.format_map(cluster_istio)
             dest_project_id = cluster_istio['project_id']
         elif mesh_istio:

--- a/slo_generator/backends/dynatrace.py
+++ b/slo_generator/backends/dynatrace.py
@@ -34,6 +34,7 @@ class DynatraceBackend:
         api_url (str): Dynatrace API URL.
         api_token (str): Dynatrace token.
     """
+
     def __init__(self, client=None, api_url=None, api_token=None):
         self.client = client
         if client is None:
@@ -50,8 +51,7 @@ class DynatraceBackend:
         Returns:
             tuple: Good event count, Bad event count.
         """
-        conf = slo_config['backend']
-        measurement = conf['measurement']
+        measurement = slo_config['spec']['service_level_indicator']
         start = (timestamp - window) * 1000
         end = timestamp * 1000
         query_good = measurement['query_good']
@@ -83,8 +83,7 @@ class DynatraceBackend:
         Returns:
             tuple: Good event count, Bad event count.
         """
-        conf = slo_config['backend']
-        measurement = conf['measurement']
+        measurement = slo_config['spec']['service_level_indicator']
         start = (timestamp - window) * 1000
         end = timestamp * 1000
         query_valid = measurement['query_valid']
@@ -92,8 +91,7 @@ class DynatraceBackend:
         good_below_threshold = measurement.get('good_below_threshold', True)
         response = self.query(start=start, end=end, **query_valid)
         LOGGER.debug(f"Result valid: {pprint.pformat(response)}")
-        return DynatraceBackend.count_threshold(response,
-                                                threshold,
+        return DynatraceBackend.count_threshold(response, threshold,
                                                 good_below_threshold)
 
     def query(self,
@@ -222,7 +220,8 @@ class DynatraceClient:
 
     @retry(retry_on_result=retry_http,
            wait_exponential_multiplier=1000,
-           wait_exponential_max=10000)
+           wait_exponential_max=10000,
+           stop_max_delay=10000)
     def request(self,
                 method,
                 endpoint,
@@ -255,9 +254,10 @@ class DynatraceClient:
         }
         if name:
             url += f'/{name}'
-        params_str = "&".join("%s=%s" % (k, v) for k, v in params.items()
-                              if v is not None)
+        params_str = "&".join(
+            "%s=%s" % (k, v) for k, v in params.items() if v is not None)
         url += f'?{params_str}'
+        LOGGER.debug(f'Running "{method}" request to {url} ...')
         if method in ['put', 'post']:
             response = req(url, headers=headers, json=post_data)
         else:

--- a/slo_generator/backends/elasticsearch.py
+++ b/slo_generator/backends/elasticsearch.py
@@ -34,6 +34,7 @@ class ElasticsearchBackend:
         client (elasticsearch.ElasticSearch): Existing ES client.
         es_config (dict): ES client configuration.
     """
+
     def __init__(self, client=None, **es_config):
         self.client = client
         if self.client is None:
@@ -52,7 +53,7 @@ class ElasticsearchBackend:
         Returns:
             tuple: A tuple (good_event_count, bad_event_count)
         """
-        measurement = slo_config['backend']['measurement']
+        measurement = slo_config['spec']['service_level_indicator']
         index = measurement['index']
         query_good = measurement['query_good']
         query_bad = measurement.get('query_bad')

--- a/slo_generator/constants.py
+++ b/slo_generator/constants.py
@@ -17,7 +17,76 @@ Constants and environment variables used in `slo-generator`.
 """
 import os
 
+# Compute
 NO_DATA = -1
 MIN_VALID_EVENTS = int(os.environ.get("MIN_VALID_EVENTS", "1"))
+
+# Global
+LATEST_MAJOR_VERSION = 'v2'
 COLORED_OUTPUT = int(os.environ.get("COLORED_OUTPUT", "0"))
 DRY_RUN = bool(int(os.environ.get("DRY_RUN", "0")))
+DEBUG = int(os.environ.get("DEBUG", "0"))
+
+# Config skeletons
+CONFIG_SCHEMA = {
+    'backends': {},
+    'exporters': {},
+    'error_budget_policies': {},
+}
+SLO_CONFIG_SCHEMA = {
+    'apiVersion': '',
+    'kind': '',
+    'metadata': {},
+    'spec': {
+        'description': '',
+        'backend': '',
+        'method': '',
+        'exporters': [],
+        'service_level_indicator': {}
+    }
+}
+
+# Providers that have changed with v2 YAML config format. This mapping helps
+# migrate them to their updated names.
+PROVIDERS_COMPAT = {
+    'Stackdriver': 'CloudMonitoring',
+    'StackdriverServiceMonitoring': 'CloudServiceMonitoring'
+}
+
+# Fields that have changed name with v2 YAML config format. This mapping helps
+# migrate them back to their former name, so that exporters are backward-
+# compatible with v1.
+METRIC_LABELS_COMPAT = {
+    'goal': 'slo_target',
+    'description': 'slo_description',
+    'burn_rate_threshold': 'alerting_burn_rate_threshold'
+}
+
+# Fields that used to be specified in top-level of YAML config are now specified
+# in metadata fields. This mapping helps migrate them back to the top level when
+# exporting reports, so that so that exporters are backward-compatible with v1.
+METRIC_METADATA_LABELS_TOP_COMPAT = ['service_name', 'feature_name', 'slo_name']
+
+
+# Colors / Status
+# pylint: disable=too-few-public-methods
+class Colors:
+    """Colors for console output."""
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+
+
+GREEN = Colors.OKGREEN
+RED = Colors.FAIL
+ENDC = Colors.ENDC
+BOLD = Colors.BOLD
+WARNING = Colors.WARNING
+FAIL = '❌'
+SUCCESS = '✅'
+RIGHT_ARROW = '➞'

--- a/slo_generator/exporters/bigquery.py
+++ b/slo_generator/exporters/bigquery.py
@@ -23,12 +23,14 @@ import pprint
 import google.api_core
 from google.cloud import bigquery
 
-from slo_generator.constants import DRY_RUN
+from slo_generator import constants
 
 LOGGER = logging.getLogger(__name__)
 
+
 class BigqueryExporter:
     """BigQuery exporter class."""
+
     def __init__(self):
         self.client = bigquery.Client(project='unset')
 
@@ -74,14 +76,14 @@ class BigqueryExporter:
         json_data = {k: v for k, v in data.items() if k in schema_fields}
         metadata = json_data.get('metadata', {})
         if isinstance(metadata, dict):
-            metadata_fields = [
-                {'key': key, 'value': value}
-                for key, value in metadata.items()
-            ]
+            metadata_fields = [{
+                'key': key,
+                'value': value
+            } for key, value in metadata.items()]
             json_data['metadata'] = metadata_fields
 
         # Write results to BQ table
-        if DRY_RUN:
+        if constants.DRY_RUN:
             LOGGER.info(f'[DRY RUN] Writing data to BigQuery: \n{json_data}')
             return []
         LOGGER.debug(f'Writing data to BigQuery:\n{json_data}')
@@ -90,9 +92,12 @@ class BigqueryExporter:
             json_rows=[json_data],
             row_ids=[row_ids],
             retry=google.api_core.retry.Retry(deadline=30))
+        status = f' Export data to {str(table_ref)}'
         if results != []:
+            status = constants.FAIL + status
             raise BigQueryError(results)
-
+        status = constants.SUCCESS + status
+        LOGGER.info(status)
         return results
 
     @staticmethod
@@ -111,12 +116,15 @@ class BigqueryExporter:
             subschema = []
             if 'fields' in row:
                 subschema = [
-                    bigquery.SchemaField(subrow['name'], subrow['type'],
+                    bigquery.SchemaField(subrow['name'],
+                                         subrow['type'],
                                          mode=subrow['mode'])
                     for subrow in row['fields']
                 ]
-            field = bigquery.SchemaField(row['name'], row['type'],
-                                         mode=row['mode'], fields=subschema)
+            field = bigquery.SchemaField(row['name'],
+                                         row['type'],
+                                         mode=row['mode'],
+                                         fields=subschema)
             final_schema.append(field)
         return final_schema
 
@@ -140,7 +148,7 @@ class BigqueryExporter:
         LOGGER.debug(f'Table schema: {pyschema}')
         table = bigquery.Table(table_name, schema=pyschema)
         table.time_partitioning = bigquery.TimePartitioning(
-            type_=bigquery.TimePartitioningType.DAY, )
+            type_=bigquery.TimePartitioningType.DAY,)
         return self.client.create_table(table)
 
     def update_schema(self, table_ref, keep=[]):
@@ -161,7 +169,8 @@ class BigqueryExporter:
 
         # Fields in TABLE_SCHEMA to add / remove
         updated_fields = [
-            field['name'] for field in TABLE_SCHEMA
+            field['name']
+            for field in TABLE_SCHEMA
             if field not in existing_schema
         ]
         extra_remote_fields = [
@@ -179,7 +188,7 @@ class BigqueryExporter:
         if updated_fields:
             LOGGER.info(f'Updated BigQuery fields: {updated_fields}')
             table.schema = BigqueryExporter.build_schema(TABLE_SCHEMA)
-            if DRY_RUN:
+            if constants.DRY_RUN:
                 LOGGER.info('[DRY RUN] Updating BigQuery schema.')
             else:
                 LOGGER.info('Updating BigQuery schema.')
@@ -187,12 +196,14 @@ class BigqueryExporter:
                 self.client.update_table(table, ['schema'])
         return table
 
+
 class BigQueryError(Exception):
     """Exception raised whenever a BigQuery error happened.
 
     Args:
         errors (list): List of errors.
     """
+
     def __init__(self, errors):
         super().__init__(BigQueryError._format(errors))
         self.errors = errors
@@ -321,10 +332,14 @@ TABLE_SCHEMA = [{
     'type': 'BOOLEAN',
     'mode': 'NULLABLE'
 }, {
-    'name': 'metadata',
-    'description': None,
-    'type': 'RECORD',
-    'mode': 'REPEATED',
+    'name':
+        'metadata',
+    'description':
+        None,
+    'type':
+        'RECORD',
+    'mode':
+        'REPEATED',
     'fields': [{
         'description': None,
         'name': 'key',

--- a/slo_generator/exporters/cloud_monitoring.py
+++ b/slo_generator/exporters/cloud_monitoring.py
@@ -84,7 +84,6 @@ class CloudMonitoringExporter(MetricsExporter):
             f"timestamp: {timestamp} value: {point.value.double_value}"
             f"{labels['service_name']}-{labels['feature_name']}-"
             f"{labels['slo_name']}-{labels['error_budget_policy_step_name']}")
-        return None
 
     def get_metric_descriptor(self, data):
         """Get Cloud Monitoring metric descriptor.

--- a/slo_generator/exporters/cloud_monitoring.py
+++ b/slo_generator/exporters/cloud_monitoring.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-`stackdriver.py`
-Stackdriver Monitoring exporter class.
+`cloud_monitoring.py`
+Cloud Monitoring exporter class.
 """
 import logging
 
@@ -24,8 +24,9 @@ from .base import MetricsExporter
 
 LOGGER = logging.getLogger(__name__)
 
-class StackdriverExporter(MetricsExporter):
-    """Stackdriver Monitoring exporter class."""
+
+class CloudMonitoringExporter(MetricsExporter):
+    """Cloud Monitoring exporter class."""
     METRIC_PREFIX = "custom.googleapis.com/"
     REQUIRED_FIELDS = ['project_id']
 
@@ -33,22 +34,22 @@ class StackdriverExporter(MetricsExporter):
         self.client = monitoring_v3.MetricServiceClient()
 
     def export_metric(self, data):
-        """Export metric to Stackdriver Monitoring. Create metric descriptor if
+        """Export metric to Cloud Monitoring. Create metric descriptor if
         it doesn't exist.
 
         Args:
-            data (dict): Data to send to Stackdriver Monitoring.
-            project_id (str): Stackdriver Monitoring project id.
+            data (dict): Data to send to Cloud Monitoring.
+            project_id (str): Cloud Monitoring project id.
 
         Returns:
-            object: Stackdriver Monitoring API result.
+            object: Cloud Monitoring API result.
         """
         if not self.get_metric_descriptor(data):
             self.create_metric_descriptor(data)
         self.create_timeseries(data)
 
     def create_timeseries(self, data):
-        """Create Stackdriver Monitoring timeseries.
+        """Create Cloud Monitoring timeseries.
 
         Args:
             data (dict): Metric data.
@@ -75,7 +76,7 @@ class StackdriverExporter(MetricsExporter):
         # Set the metric value.
         point.value.double_value = data['value']
 
-        # Record the timeseries to Stackdriver Monitoring.
+        # Record the timeseries to Cloud Monitoring.
         project = self.client.project_path(data['project_id'])
         result = self.client.create_time_series(project, [series])
         labels = series.metric.labels
@@ -86,7 +87,7 @@ class StackdriverExporter(MetricsExporter):
         return result
 
     def get_metric_descriptor(self, data):
-        """Get Stackdriver Monitoring metric descriptor.
+        """Get Cloud Monitoring metric descriptor.
 
         Args:
             data (dict): Metric data.
@@ -102,7 +103,7 @@ class StackdriverExporter(MetricsExporter):
             return None
 
     def create_metric_descriptor(self, data):
-        """Create Stackdriver Monitoring metric descriptor.
+        """Create Cloud Monitoring metric descriptor.
 
         Args:
             data (dict): Metric data.

--- a/slo_generator/exporters/cloud_monitoring.py
+++ b/slo_generator/exporters/cloud_monitoring.py
@@ -78,13 +78,13 @@ class CloudMonitoringExporter(MetricsExporter):
 
         # Record the timeseries to Cloud Monitoring.
         project = self.client.project_path(data['project_id'])
-        result = self.client.create_time_series(project, [series])
+        self.client.create_time_series(project, [series])
         labels = series.metric.labels
         LOGGER.debug(
             f"timestamp: {timestamp} value: {point.value.double_value}"
             f"{labels['service_name']}-{labels['feature_name']}-"
             f"{labels['slo_name']}-{labels['error_budget_policy_step_name']}")
-        return result
+        return None
 
     def get_metric_descriptor(self, data):
         """Get Cloud Monitoring metric descriptor.

--- a/slo_generator/exporters/pubsub.py
+++ b/slo_generator/exporters/pubsub.py
@@ -16,8 +16,13 @@
 Pubsub exporter class.
 """
 import json
+import logging
 
 from google.cloud import pubsub_v1
+
+from slo_generator import constants
+
+LOGGER = logging.getLogger(__name__)
 
 
 class PubsubExporter:  # pylint: disable=too-few-public-methods
@@ -43,4 +48,11 @@ class PubsubExporter:  # pylint: disable=too-few-public-methods
         topic_path = self.publisher.topic_path(project_id, topic_name)
         data = json.dumps(data, indent=4)
         data = data.encode('utf-8')
-        return self.publisher.publish(topic_path, data=data).result()
+        res = self.publisher.publish(topic_path, data=data).result()
+        status = f' Export data to {topic_path}'
+        if not isinstance(res, str):
+            status = constants.FAIL + status
+        else:
+            status = constants.SUCCESS + status
+        LOGGER.info(status)
+        return res

--- a/slo_generator/utils.py
+++ b/slo_generator/utils.py
@@ -85,8 +85,7 @@ def load_config(path, ctx=os.environ, kind=None):
         elif abspath.is_file():
             config = parse_config(path=str(abspath.resolve()), ctx=ctx)
         else:
-            LOGGER.warning(
-                f'Path {abspath} not found. Trying to load from string')
+            LOGGER.warning(f'Path {path} not found. Trying to load from string')
             config = parse_config(content=str(path), ctx=ctx)
 
         # Filter on 'kind'

--- a/slo_generator/utils.py
+++ b/slo_generator/utils.py
@@ -89,9 +89,10 @@ def load_config(path, ctx=os.environ, kind=None):
                 f'Path {abspath} not found. Trying to load from string')
             config = parse_config(content=str(path), ctx=ctx)
 
-        if kind and config and kind != config.get('kind', ''):
-            config = None
-
+        # Filter on 'kind'
+        if kind:
+            if not isinstance(config, dict) or kind != config.get('kind', ''):
+                config = None
         return config
 
     except OSError as exc:

--- a/slo_generator/utils.py
+++ b/slo_generator/utils.py
@@ -18,7 +18,7 @@ Utility functions.
 from datetime import datetime
 import argparse
 import collections
-import glob
+import errno
 import importlib
 import logging
 import os
@@ -26,39 +26,86 @@ import pprint
 import re
 import sys
 import warnings
-import yaml
+from pathlib import Path
 
 from dateutil import tz
+import yaml
 
-from google.auth._default import _CLOUD_SDK_CREDENTIALS_WARNING
+from slo_generator.constants import DEBUG
+
+try:
+    from google.cloud import storage
+    GCS_ENABLED = True
+except ImportError:
+    GCS_ENABLED = False
 
 LOGGER = logging.getLogger(__name__)
 
 
-def list_slo_configs(path):
-    """List all SLO configs from path.
+def load_configs(path, ctx=os.environ, kind=None):
+    """Load multiple slo-generator configs from a folder path.
 
-    If path is a file, normalize the path and return it as a list with one
-    element.
+    Args:
+        path (str): Folder path.
+        ctx (dict): Context for variable replacement.
+        kind (str): Config kind filter.
 
-    If path is a folder, get all SLO configs from folder (files starting with
-    slo_*), normalize their paths and return them as a list.
+    Returns:
+        list: List of configs downloaded and parsed.
     """
-    path = normalize(path)
-    if os.path.isfile(path):
-        paths = [path]
-    elif os.path.isdir(path):
-        paths = sorted(glob.glob(f'{path}/slo_*.yaml'))
-    else:
-        raise Exception(f'SLO Config path "{path}" is not a file or folder.')
-    return paths
+    configs = [
+        load_config(str(p), ctx=ctx, kind=kind)
+        for p in sorted(Path(path).glob('*.yaml'))
+    ]
+    return [cfg for cfg in configs if cfg]
 
 
-def parse_config(path, ctx=os.environ):
+def load_config(path, ctx=os.environ, kind=None):
+    """Load any slo-generator config, from a local path, a GCS URL, or directly
+    from a string content.
+
+    Args:
+        path (str): GCS URL, file path, or data as string.
+        ctx (dict): Context for variable replacement.
+        kind (str): Config kind filter.
+
+    Returns:
+        dict: Config downloaded and parsed.
+    """
+    abspath = Path(path)
+    try:
+        if path.startswith('gs://'):
+            if not GCS_ENABLED:
+                warnings.warn(
+                    'To load a file from GCS, you need `google-cloud-storage` '
+                    'installed. Please install it using pip by running '
+                    '`pip install google-cloud-storage`', ImportWarning)
+                sys.exit(1)
+            config = parse_config(content=download_gcs_file(str(path)), ctx=ctx)
+        elif abspath.is_file():
+            config = parse_config(path=str(abspath.resolve()), ctx=ctx)
+        else:
+            LOGGER.warning(
+                f'Path {abspath} not found. Trying to load from string')
+            config = parse_config(content=str(path), ctx=ctx)
+
+        if kind and config and kind != config.get('kind', ''):
+            config = None
+
+        return config
+
+    except OSError as exc:
+        if exc.errno == errno.ENAMETOOLONG:  # filename too long, string content
+            return parse_config(content=str(path), ctx=ctx)
+        raise
+
+
+def parse_config(path=None, content=None, ctx=os.environ):
     """Load a yaml configuration file and resolve environment variables in it.
 
     Args:
         path (str): the path to the yaml file.
+        content (str): the config content as a dict string.
         ctx (dict): Context to replace env variables from (defaults to
             `os.environ`).
 
@@ -84,17 +131,18 @@ def parse_config(path, ctx=os.environ):
                 try:
                     full_value = full_value.replace(f'${{{var}}}', ctx[var])
                 except KeyError as exception:
-                    LOGGER.error(
-                        f'Environment variable "{var}" should be set.',
-                        exc_info=True)
+                    LOGGER.error(f'Environment variable "{var}" should be set.',
+                                 exc_info=True)
                     raise exception
             content = full_value
         return content
 
-    with open(path) as config:
-        content = config.read()
+    if path:
+        with Path(path).open() as config:
+            content = config.read()
+    if ctx:
         content = replace_env_vars(content, ctx)
-        data = yaml.safe_load(content)
+    data = yaml.safe_load(content)
 
     LOGGER.debug(pprint.pformat(data))
     return data
@@ -102,9 +150,8 @@ def parse_config(path, ctx=os.environ):
 
 def setup_logging():
     """Setup logging for the CLI."""
-    debug = os.environ.get("DEBUG", "0")
-    print("DEBUG: %s" % debug)
-    if debug == "1":
+    if DEBUG == 1:
+        print(f'DEBUG mode is enabled. DEBUG={DEBUG}')
         level = logging.DEBUG
     else:
         level = logging.INFO
@@ -115,7 +162,13 @@ def setup_logging():
     logging.getLogger('googleapiclient').setLevel(logging.ERROR)
 
     # Ignore Cloud SDK warning when using a user instead of service account
-    warnings.filterwarnings("ignore", message=_CLOUD_SDK_CREDENTIALS_WARNING)
+    try:
+        # pylint: disable=import-outside-toplevel
+        from google.auth._default import _CLOUD_SDK_CREDENTIALS_WARNING
+        warnings.filterwarnings("ignore",
+                                message=_CLOUD_SDK_CREDENTIALS_WARNING)
+    except ImportError:
+        pass
 
 
 def get_human_time(timestamp, timezone=None):
@@ -143,21 +196,76 @@ def get_human_time(timestamp, timezone=None):
     dt_tz = dt_utc.replace(tzinfo=to_zone)
     timeformat = '%Y-%m-%dT%H:%M:%S.%f%z'
     date_str = datetime.strftime(dt_tz, timeformat)
-    date_str = "{0}:{1}".format(
-        date_str[:-2], date_str[-2:]
-    )
+    date_str = "{0}:{1}".format(date_str[:-2], date_str[-2:])
     return date_str
 
-def normalize(path):
-    """Converts a path to an absolute path.
+
+def get_exporters(config, spec):
+    """Get SLO exporters configs from spec and global config.
 
     Args:
-        path (str): Input path.
+        config (dict): Global config.
+        spec (dict): SLO config.
 
     Returns:
-        str: Absolute path.
+        list: List of dict containing exporters configurations.
     """
-    return os.path.abspath(path)
+    all_exporters = config.get('exporters', {})
+    spec_exporters = spec.get('exporters', [])
+    exporters = []
+    for exporter in spec_exporters:
+        if exporter not in all_exporters.keys():
+            LOGGER.warning(
+                f'Exporter "{exporter}" not found in config. Skipping.')
+            continue
+        exporter_data = all_exporters[exporter]
+        exporter_data['name'] = exporter
+        exporter_data['class'] = capitalize(
+            snake_to_caml(exporter.split('/')[0]))
+        exporters.append(exporter_data)
+    return exporters
+
+
+def get_backend(config, spec):
+    """Get SLO backend config from spec and global config.
+
+    Args:
+        config (dict): Global config.
+        spec (dict): SLO config.
+
+    Returns:
+        list: List of dict containing exporters configurations.
+    """
+    all_backends = config.get('backends', {})
+    spec_backend = spec['backend']
+    backend_data = {}
+    if spec_backend not in all_backends.keys():
+        LOGGER.error(f'Backend "{spec_backend}" not found in config. Exiting.')
+        sys.exit(0)
+    backend_data = all_backends[spec_backend]
+    backend_data['name'] = spec_backend
+    backend_data['class'] = capitalize(snake_to_caml(
+        spec_backend.split('/')[0]))
+    return backend_data
+
+
+def get_error_budget_policy(config, spec):
+    """Get error budget policy from spec and global config.
+
+    Args:
+        config (dict): Global config.
+        spec (dict): SLO config.
+
+    Returns:
+        list: List of dict containing exporters configurations.
+    """
+    all_ebp = config.get('error_budget_policies', {})
+    spec_ebp = spec.get('error_budget_policy', 'default')
+    if spec_ebp not in all_ebp.keys():
+        LOGGER.error(
+            f'Error budget policy "{spec_ebp}" not found in config. Exiting.')
+        sys.exit(0)
+    return all_ebp[spec_ebp]
 
 
 def get_backend_cls(backend):
@@ -186,27 +294,28 @@ def get_exporter_cls(exporter):
     return import_cls(exporter, expected_type)
 
 
-def import_cls(klass_name, expected_type):
+def import_cls(cls_name, expected_type):
     """Import class or method dynamically from full name.
-    If the classname is not fully qualified, import in current sub modules.
+    If `cls_name` is not part of the core, try import from local path (plugins).
 
     Args:
-        klass_name: the class name to import
-        expected_type: the type of class expected
+        cls_name: Class name to import.
+        expected_type: Type of class expected.
 
     Returns:
         obj: Imported class or method object.
     """
-    if "." in klass_name:
-        package, name = klass_name.rsplit(".", maxsplit=1)
+    # plugin class
+    if "." in cls_name:
+        package, name = cls_name.rsplit(".", maxsplit=1)
         return import_dynamic(package, name, prefix=expected_type)
 
-    # else
+    # slo-generator core class
     modules_name = f"{expected_type.lower()}s"
-    full_klass_name = f'{klass_name}{expected_type}'
-    filename = re.sub(r'(?<!^)(?=[A-Z])', '_', klass_name).lower()
+    full_cls_name = f'{cls_name}{expected_type}'
+    filename = re.sub(r'(?<!^)(?=[A-Z])', '_', cls_name).lower()
     return import_dynamic(f'slo_generator.{modules_name}.{filename}',
-                          full_klass_name,
+                          full_cls_name,
                           prefix=expected_type)
 
 
@@ -223,12 +332,54 @@ def import_dynamic(package, name, prefix="class"):
     try:
         return getattr(importlib.import_module(package), name)
     except Exception as exception:  # pylint: disable=W0703
-        LOGGER.error(
-            f'{prefix} "{package}.{name}" not found, check '
-            f'package and class name are valid, or that importing it doesn\'t '
-            f'result in an exception.')
-        LOGGER.debug(exception, exc_info=True)
-        raise exception
+        dep = package.split('.')[-1]
+        warnings.warn(
+            f'{prefix} "{package}.{name}" not found.\nPlease ensure that:\n'
+            f'1. Package and class name are valid.\n'
+            f'2. Extra dependency {dep} is installed. If not, install it '
+            f'locally with "pip install slo-generator[{dep}]" or remotely '
+            f'by adding "slo-generator[{dep}]" to your requirements.txt.',
+            ImportWarning)
+        if DEBUG:
+            LOGGER.debug(exception, exc_info=True)
+        return None
+
+
+def capitalize(word):
+    """Only capitalize the first letter of a word, even when written in
+    CamlCase.
+
+    Args:
+        word (str): Input string.
+
+    Returns:
+        str: Input string with first letter capitalized.
+    """
+    return re.sub('([a-zA-Z])', lambda x: x.groups()[0].upper(), word, 1)
+
+
+def snake_to_caml(word):
+    """Convert a string written in snake_case to a string in CamlCase.
+
+    Args:
+        word (str): Input string.
+
+    Returns:
+        str: Output string.
+    """
+    return re.sub('_.', lambda x: x.group()[1].upper(), word)
+
+
+def caml_to_snake(word):
+    """Convert a string written in CamlCase to a string written in snake_case.
+
+    Args:
+        word (str): Input string.
+
+    Returns:
+        str: Output string.
+    """
+    return re.sub(r'(?<!^)(?=[A-Z])', '_', word).lower()
 
 
 def dict_snake_to_caml(data):
@@ -241,9 +392,6 @@ def dict_snake_to_caml(data):
     Returns:
         dict: Output dictionary.
     """
-    def snake_to_caml(word):
-        return re.sub('_.', lambda x: x.group()[1].upper(), word)
-
     return apply_func_dict(data, snake_to_caml)
 
 
@@ -282,14 +430,32 @@ def str2bool(string):
     raise argparse.ArgumentTypeError('Boolean value expected.')
 
 
-# pylint: disable=too-few-public-methods
-class Colors:
-    """Colors for console output."""
-    HEADER = '\033[95m'
-    OKBLUE = '\033[94m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
-    BOLD = '\033[1m'
-    UNDERLINE = '\033[4m'
+def download_gcs_file(url):
+    """Download config from GCS.
+
+    Args:
+        url: Config URL.
+
+    Returns:
+        dict: Loaded configuration.
+    """
+    client = storage.Client()
+    bucket, filepath = decode_gcs_url(url)
+    bucket = client.get_bucket(bucket)
+    blob = bucket.blob(filepath)
+    return blob.download_as_string(client=None).decode('utf-8')
+
+
+def decode_gcs_url(url):
+    """Decode GCS URL.
+
+    Args:
+        url (str): GCS URL.
+
+    Returns:
+        tuple: (bucket_name, file_path)
+    """
+    split_url = url.split('/')
+    bucket_name = split_url[2]
+    file_path = '/'.join(split_url[3:])
+    return (bucket_name, file_path)

--- a/slo_generator/utils.py
+++ b/slo_generator/utils.py
@@ -154,11 +154,13 @@ def setup_logging():
     if DEBUG == 1:
         print(f'DEBUG mode is enabled. DEBUG={DEBUG}')
         level = logging.DEBUG
+        format_str = '%(name)s - %(levelname)s - %(message)s'
     else:
         level = logging.INFO
+        format_str = '%(levelname)s - %(message)s'
     logging.basicConfig(stream=sys.stdout,
                         level=level,
-                        format='%(name)s - %(levelname)s - %(message)s',
+                        format=format_str,
                         datefmt='%m/%d/%Y %I:%M:%S')
     logging.getLogger('googleapiclient').setLevel(logging.ERROR)
 


### PR DESCRIPTION
This PR adds support for the new slo-generator configuration v2 format, which basically:
* Upgrades the SLO config to a k8s-compatible one, and field names that make more sense
* Adds a new slo-generator config, that is a super-set of the existing error budget policy config (which is now obsolete)