### PR TITLE
feat!: Upgrade slo-generator CLI to Click library

### DIFF
--- a/slo_generator/cli.py
+++ b/slo_generator/cli.py
@@ -16,114 +16,168 @@
 Command-Line interface of `slo-generator`.
 """
 
-import argparse
 import logging
 import os
 import sys
 import time
+from importlib.metadata import version as get_package_version
+from pathlib import Path
 
-import slo_generator.utils as utils
-from slo_generator.compute import compute
+import click
+from slo_generator import utils
+from slo_generator.compute import compute as _compute
+from slo_generator.migrations import migrator
+from slo_generator.constants import LATEST_MAJOR_VERSION
 
 sys.path.append(os.getcwd())  # dynamic backend loading
 
 LOGGER = logging.getLogger(__name__)
 
 
-def main():
-    """slo-generator CLI entrypoint."""
-    args = parse_args(sys.argv[1:])
-    cli(args)
-
-
-def cli(args):
-    """Main CLI function.
-
-    Args:
-        args (Namespace): Argparsed CLI parameters.
-
-    Returns:
-        dict: Dict of all reports indexed by config file path.
-    """
+@click.group(invoke_without_command=True)
+@click.option('--version',
+              '-v',
+              is_flag=True,
+              help='Show slo-generator version.')
+@click.pass_context
+def main(ctx, version):
+    """CLI entrypoint."""
     utils.setup_logging()
-    export = args.export
-    delete = args.delete
-    timestamp = args.timestamp
+    if ctx.invoked_subcommand is None or version:
+        ver = get_package_version('slo-generator')
+        print(f'slo-generator v{ver}')
+        sys.exit(0)
+
+
+@main.command()
+@click.option('--slo-config',
+              '-f',
+              type=click.Path(),
+              required=True,
+              help='SLO config path')
+@click.option('--config',
+              '-c',
+              type=click.Path(exists=True),
+              default='config.yaml',
+              show_default=True,
+              help='slo-generator config path')
+@click.option('--export',
+              '-e',
+              is_flag=True,
+              help='Export SLO report to exporters')
+@click.option('--delete',
+              '-d',
+              is_flag=True,
+              help='Delete mode (used for backends with SLO APIs)')
+@click.option('--timestamp',
+              '-t',
+              type=float,
+              default=time.time(),
+              help='End timestamp for query.')
+def compute(slo_config, config, export, delete, timestamp):
+    """Compute SLO report."""
     start = time.time()
 
-    # Load error budget policy
-    LOGGER.debug(f"Loading Error Budget config from {args.error_budget_policy}")
-    eb_path = utils.normalize(args.error_budget_policy)
-    eb_policy = utils.parse_config(eb_path)
+    # Load slo-generator config
+    LOGGER.debug(f"Loading slo-generator config from {config}")
+    config_dict = utils.load_config(config)
 
-    # Parse SLO folder for configs
-    slo_configs = utils.list_slo_configs(args.slo_config)
+    # Load SLO config(s)
+    if Path(slo_config).is_dir():
+        slo_configs = utils.load_configs(slo_config,
+                                         kind='ServiceLevelObjective')
+    else:
+        slo_configs = [
+            utils.load_config(slo_config, kind='ServiceLevelObjective')
+        ]
+
     if not slo_configs:
-        LOGGER.error(f'No SLO configs found in SLO folder {args.slo_config}.')
+        LOGGER.error(f'No SLO configs found in {slo_config}.')
+        sys.exit(1)
 
     # Load SLO configs and compute SLO reports
     all_reports = {}
-    for path in slo_configs:
-        slo_config_name = path.split("/")[-1]
-        LOGGER.debug(f'Loading SLO config "{slo_config_name}"')
-        slo_config = utils.parse_config(path)
-        reports = compute(slo_config,
-                          eb_policy,
-                          timestamp=timestamp,
-                          do_export=export,
-                          delete=delete)
-        all_reports[path] = reports
+    for slo_config_dict in slo_configs:
+        reports = _compute(slo_config_dict,
+                           config_dict,
+                           timestamp=timestamp,
+                           do_export=export,
+                           delete=delete)
+        if reports:
+            name = slo_config_dict['metadata']['name']
+            all_reports[name] = reports
     end = time.time()
     duration = round(end - start, 1)
     LOGGER.info(f'Run summary | SLO Configs: {len(slo_configs)} | '
-                f'Error Budget Policy Steps: {len(eb_policy)} | '
-                f'Total: {len(slo_configs) * len(eb_policy)} | '
                 f'Duration: {duration}s')
+    LOGGER.debug(all_reports)
     return all_reports
 
 
-def parse_args(args):
-    """Parse CLI arguments.
-
-    Args:
-        args (list): List of args passed from CLI.
-
-    Returns:
-        obj: Args parsed by ArgumentParser.
-    """
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--slo-config',
-                        '-f',
-                        type=str,
-                        required=False,
-                        help='SLO configuration file (JSON / YAML)')
-    parser.add_argument('--error-budget-policy',
-                        '-b',
-                        type=str,
-                        required=False,
-                        default='error_budget_policy.yaml',
-                        help='Error budget policy file (JSON / YAML)')
-    parser.add_argument('--export',
-                        '-e',
-                        type=utils.str2bool,
-                        nargs='?',
-                        const=True,
-                        default=False,
-                        help="Export SLO reports")
-    parser.add_argument('--delete',
-                        '-d',
-                        type=utils.str2bool,
-                        nargs='?',
-                        const=True,
-                        default=False,
-                        help="Delete SLO (use for backends with APIs).")
-    parser.add_argument('--timestamp',
-                        '-t',
-                        type=int,
-                        default=None,
-                        help="End timestamp for query.")
-    return parser.parse_args(args)
+# pylint: disable=import-error,import-outside-toplevel
+@main.command()
+@click.pass_context
+@click.option('--config',
+              envvar='CONFIG_PATH',
+              required=True,
+              help='slo-generator configuration file path.')
+@click.option('--signature-type',
+              envvar='GOOGLE_FUNCTION_SIGNATURE_TYPE',
+              default='http',
+              type=click.Choice(['http', 'cloudevent']),
+              help='Signature type')
+@click.option('--target',
+              envvar='GOOGLE_FUNCTION_SIGNATURE_TYPE',
+              default='run_compute',
+              help='Target function name')
+def api(ctx, config, signature_type, target):
+    """Run an API that can receive requests (supports both 'http' and
+    'cloudevents' signature types)."""
+    from functions_framework._cli import _cli
+    os.environ['CONFIG_PATH'] = config
+    os.environ['GOOGLE_FUNCTION_SIGNATURE_TYPE'] = signature_type
+    os.environ['GOOGLE_FUNCTION_TARGET'] = target
+    ctx.invoke(_cli,
+               target=target,
+               source=Path(__file__).parent / 'api' / 'main.py',
+               signature_type=signature_type)
 
 
-if __name__ == '__main__':
-    main()
+@main.command()
+@click.option('--source',
+              '-s',
+              type=click.Path(exists=True, resolve_path=True, readable=True),
+              required=True,
+              default=Path.cwd(),
+              help='Source SLO configs folder')
+@click.option('--target',
+              '-t',
+              type=click.Path(resolve_path=True),
+              default=Path.cwd(),
+              required=True,
+              help='Target SLO configs folder')
+@click.option('--error-budget-policy-path',
+              '-b',
+              type=click.Path(exists=True, resolve_path=True, readable=True),
+              required=False,
+              default='error_budget_policy.yaml',
+              help='Error budget policy path')
+@click.option('--glob',
+              type=str,
+              required=False,
+              default='**/slo_*.yaml',
+              help='Glob expression to seek SLO configs in subpaths')
+@click.option('--version',
+              type=str,
+              required=False,
+              default=LATEST_MAJOR_VERSION,
+              show_default=True,
+              help='SLO generate major version to migrate towards')
+@click.option('--quiet',
+              '-q',
+              is_flag=True,
+              default=False,
+              help='Do not ask for user input and auto-generate config keys')
+def migrate(**kwargs):
+    """Migrate SLO configs from v1 to v2."""
+    migrator.do_migrate(**kwargs)

--- a/slo_generator/cli.py
+++ b/slo_generator/cli.py
@@ -20,8 +20,8 @@ import logging
 import os
 import sys
 import time
-from importlib.metadata import version as get_package_version
 from pathlib import Path
+from pkg_resources import get_distribution
 
 import click
 from slo_generator import utils
@@ -44,7 +44,7 @@ def main(ctx, version):
     """CLI entrypoint."""
     utils.setup_logging()
     if ctx.invoked_subcommand is None or version:
-        ver = get_package_version('slo-generator')
+        ver = get_distribution('slo-generator').version
         print(f'slo-generator v{ver}')
         sys.exit(0)
 


### PR DESCRIPTION
This PR upgrades the existing CLI to use Click, a library made for building much more robust CLIs (type checking, file existence check, OOTB flags, etc...).

The PR also renames the existing command: `slo-generator` --> `slo-generator compute` which makes it a breaking change, and adds two new commands, `slo-generator api` that runs the Cloud Functions Framework API, and `slo-generator migrate` to run the migration script from the CLI.

Fixes #120 