### PR TITLE
refactor: Update .gitignore and Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,6 @@ htmlcov/
 *.tfstate.*.backup
 .vscode
 .env
+venv/
+.venv/
 reports/

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ htmlcov/
 *.tfvars
 *.tfstate.backup
 *.tfstate.*.backup
+.vscode
+.env
+reports/

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@
 # useful targets:
 #	make clean -- clean distutils
 #	make coverage -- code coverage report
-#	make flake8 -- flake8 checks
-#	make pylint -- source code checks
-#	make tests -- run all of the tests
-#	make unit -- runs the unit tests
+#	make test -- run all tests
+#	make lint -- run lint tests
+#	make unit -- runs unit tests
+#   make integration -- runs integration tests
 ########################################################
 # variable section
 


### PR DESCRIPTION
This PR updates the .gitignore and adds a few capabilities to the Makefile, which can now run all tests within Docker, build and push an API to Cloud Run, and run integration tests.

Basic commands are:
```
make # run everything
make unit # run unittests
make lint # run linting tests
make integration # run integration tests (require filling the samples/.env.sample file and sourcing it prior to running this)
```

but more granular commands exist to run only specific tests (cf Makefile).