### PR TITLE
error variable measurement

### DIFF
--- a/slo_generator/backends/dynatrace.py
+++ b/slo_generator/backends/dynatrace.py
@@ -51,10 +51,9 @@ class DynatraceBackend:
         Returns:
             float: SLI value.
         """
-        conf = slo_config['backend']
         start = (timestamp - window) * 1000
         end = timestamp * 1000
-        measurement = conf['measurement']
+        measurement = slo_config['spec']['service_level_indicator']
         slo_id = measurement['slo_id']
         data = self.retrieve_slo(start, end, slo_id)
         LOGGER.debug(f"Result SLO: {pprint.pformat(data)}")


### PR DESCRIPTION
When a run  slo-generator compute i got two errors
it seems code in dynatrace.py to get slo measurement is not good

i have replace
   conf = slo_config['backend']
   measurement = conf['measurement']
by
   measurement = slo_config['spec']['service_level_indicator']

(same as in datadog.py)

ERRORS
--------------
conf = slo_config['backend']
KeyError: 'backend'

then

Traceback (most recent call last):
  File "/home/laurendeau/project/slo-generator-project/venv/lib/python3.8/site-packages/slo_generator/report.py", line 216, in run_backend
    data = method(self.timestamp, self.window, config)
  File "/home/laurendeau/project/slo-generator-project/venv/lib/python3.8/site-packages/slo_generator/backends/dynatrace.py", line 58, in query_sli
    measurement = conf['measurement']