### PR TITLE
Add Prometheus Self exporter for API mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ int_prom:
 
 # Run API locally
 run_api:
-	slo-generator api --target=run_compute --signature-type=http
+	slo-generator api --target=run_compute --signature-type=http -c samples/config.yaml
 
 # Local Docker build / push
 docker_build:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ alerting directly on metrics or on **SLI > SLO** thresholds.
 
 ### Requirements
 
-* `python3.7` and above
+* `python3.9` and above
 * `pip3`
 
 ### Installation

--- a/docs/providers/prometheus.md
+++ b/docs/providers/prometheus.md
@@ -154,6 +154,18 @@ Optional fields:
 
 **&rightarrow; [Full SLO config](../../samples/prometheus/slo_prom_metrics_availability_query_sli.yaml)**
 
+## Self Exporter (API mode)
+
+When running slo-generator as an API, you can enable `prometheus_self` exporter, which will 
+expose all metrics on a standard `/metrics` endpoint, instead of pushing them to a gateway.
+
+```yaml
+exporters:
+  prometheus_self: { }
+```
+
+***Note:*** The metrics endpoint will be available after a first successful SLO request. 
+Before that, it's going to act as if it was endpoint of the generator API.
 
 ### Examples
 

--- a/samples/config.yaml
+++ b/samples/config.yaml
@@ -42,6 +42,7 @@ exporters:
   pubsub:
     project_id: ${PUBSUB_PROJECT_ID}
     topic_name: ${PUBSUB_TOPIC_NAME}
+  prometheus_self: { }
 
 error_budget_policies:
   default:

--- a/slo_generator/exporters/prometheus_self.py
+++ b/slo_generator/exporters/prometheus_self.py
@@ -1,0 +1,67 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#            http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+`prometheus_self.py`
+Prometheus Self exporter class.
+"""
+import logging
+
+from flask import current_app, make_response
+from prometheus_client import Gauge, generate_latest
+
+from .base import MetricsExporter
+
+LOGGER = logging.getLogger(__name__)
+
+class PrometheusSelfExporter(MetricsExporter):
+    """Prometheus exporter class which uses
+    the API mode of itself to export the metrics."""
+    REGISTERED_URL = False
+    REGISTERED_METRICS = {}
+
+    def __init__(self):
+        if not self.REGISTERED_URL:
+            current_app.add_url_rule('/metrics', view_func=self.serve_metrics)
+            PrometheusSelfExporter.REGISTERED_URL = True
+
+    @staticmethod
+    def serve_metrics():
+        """Serves prometheus metrics
+
+        Returns:
+            object: Flask HTTP Response
+        """
+        resp = make_response(generate_latest(), 200)
+        resp.mimetype = 'text/plain'
+        return resp
+
+    def export_metric(self, data):
+        """Export data to Prometheus global registry.
+
+        Args:
+            data (dict): Metric data.
+        """
+        name = data['name']
+        description = data['description']
+        value = data['value']
+
+        # Write timeseries w/ metric labels.
+        labels = data['labels']
+        gauge = self.REGISTERED_METRICS.get(name)
+        if gauge is None:
+            gauge = Gauge(name,
+                          description,
+                          labelnames=labels.keys())
+            PrometheusSelfExporter.REGISTERED_METRICS[name] = gauge
+        gauge.labels(*labels.values()).set(value)

--- a/tests/unit/fixtures/exporters.yaml
+++ b/tests/unit/fixtures/exporters.yaml
@@ -43,3 +43,5 @@
           # data labels
           - good_events_count
           - bad_events_count
+
+  - class: PrometheusSelf

--- a/tests/unit/test_compute.py
+++ b/tests/unit/test_compute.py
@@ -147,6 +147,9 @@ class TestCompute(unittest.TestCase):
     def test_export_prometheus(self, mock):
         export(SLO_REPORT, EXPORTERS[3])
 
+    def test_export_prometheus_self(self):
+        export(SLO_REPORT, EXPORTERS[7])
+
     @patch.object(Metric, 'send', mock_dd_metric_send)
     def test_export_datadog(self):
         export(SLO_REPORT, EXPORTERS[4])


### PR DESCRIPTION
This is a rather hacky solution due to functions framework, but it works and removes the not-so-ideal dependency of pushgateway when running in an API mode. If needed, I can explain the motivation/use case a bit more.