### PR TITLE
fix: support custom exporters

### DIFF
--- a/slo_generator/utils.py
+++ b/slo_generator/utils.py
@@ -230,8 +230,11 @@ def get_exporters(config, spec):
             continue
         exporter_data = all_exporters[exporter]
         exporter_data['name'] = exporter
-        exporter_data['class'] = capitalize(
-            snake_to_caml(exporter.split('/')[0]))
+        if '.' in exporter: # support custom exporter
+            exporter_data['class'] = exporter
+        else: # core exporter
+            exporter_data['class'] = capitalize(
+                snake_to_caml(exporter.split('/')[0]))
         exporters.append(exporter_data)
     return exporters
 


### PR DESCRIPTION
currently, custom exporters are failing to load due to `capitalize`, this
will add the same logic (avoid capitalize custom class name) to `get_exporters` used in `get_backend`.

```
ERROR - Exporter not found in shared config.
Traceback (most recent call last):
  File "/Users/pmishra/Data/failover_scheduler/slo/slo-generator/slo_generator/compute.py", line 127, in export
    raise ImportError('Exporter not found in shared config.')
ImportError: Exporter not found in shared config.
```