### PR TITLE
ci: replace deprecated `set-output` command with `GITHUB_OUTPUT` environment variable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,9 +20,9 @@ jobs:
       - name: Check release version
         id: check-tag
         run: |
-          echo ::set-output name=version::$(echo ${{ github.event.ref }} | cut -d / -f 3 | cut -c2-)
+          echo version=$(echo ${{ github.event.ref }} | cut -d / -f 3 | cut -c2-) >> $GITHUB_OUTPUT
           if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo ::set-output name=match::true
+              echo match=true >> $GITHUB_OUTPUT
           fi
 
       - name: Set up Cloud SDK

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
           if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               echo match=true >> $GITHUB_OUTPUT
           fi
+        shell: bash
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,9 +20,9 @@ jobs:
       - name: Check release version
         id: check-tag
         run: |
-          echo version=$(echo ${{ github.event.ref }} | cut -d / -f 3 | cut -c2-) >> $GITHUB_OUTPUT
+          echo "version=$(echo ${{ github.event.ref }} | cut -d / -f 3 | cut -c2-)" >> $GITHUB_OUTPUT
           if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo match=true >> $GITHUB_OUTPUT
+              echo "match=true" >> $GITHUB_OUTPUT
           fi
         shell: bash
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,6 @@ jobs:
           if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               echo "match=true" >> $GITHUB_OUTPUT
           fi
-        shell: bash
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,9 +18,9 @@ jobs:
       - name: Check release version
         id: check-tag
         run: |
-          echo ::set-output name=version::$(echo ${{ github.event.ref }} | cut -d / -f 3 | cut -c2-)
+          echo version=$(echo ${{ github.event.ref }} | cut -d / -f 3 | cut -c2-) >> $GITHUB_OUTPUT
           if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo ::set-output name=match::true
+              echo match=true >> $GITHUB_OUTPUT
           fi
 
       - name: Set up Cloud SDK

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,9 +18,9 @@ jobs:
       - name: Check release version
         id: check-tag
         run: |
-          echo version=$(echo ${{ github.event.ref }} | cut -d / -f 3 | cut -c2-) >> $GITHUB_OUTPUT
+          echo "version=$(echo ${{ github.event.ref }} | cut -d / -f 3 | cut -c2-)" >> $GITHUB_OUTPUT
           if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo match=true >> $GITHUB_OUTPUT
+              echo "match=true" >> $GITHUB_OUTPUT
           fi
         shell: bash
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,6 @@ jobs:
           if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               echo "match=true" >> $GITHUB_OUTPUT
           fi
-        shell: bash
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,7 @@ jobs:
           if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               echo match=true >> $GITHUB_OUTPUT
           fi
+        shell: bash
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0


### PR DESCRIPTION
resolved #251 