### PR TITLE
Shorter window can not have more bad events than a longer window

### DIFF
--- a/slo_generator/compute.py
+++ b/slo_generator/compute.py
@@ -118,8 +118,7 @@ def compute(
                 info = "slo_id " + str(
                     reportsWindow[key]["metadata"]["labels"]["slo_id"]
                 )
-            msg = f"{info}"
-            msg += f" | "
+            msg = f"{info} | "
             msg += f"Window {reportsWindowName[lastKey]} ({badEvents[lastKey]}) "
             msg += (
                 "has more bad events than {reportsWindowName[key]} ({badEvents[key]})"

--- a/slo_generator/compute.py
+++ b/slo_generator/compute.py
@@ -27,8 +27,7 @@ from slo_generator.report import SLOReport
 
 LOGGER = logging.getLogger(__name__)
 
-
-# pylint: disable=too-many-arguments,too-many-locals
+# pylint: disable=too-many-arguments,too-many-locals,R0915
 def compute(
     slo_config: dict,
     config: dict,

--- a/slo_generator/compute.py
+++ b/slo_generator/compute.py
@@ -79,7 +79,7 @@ def compute(
             client=client,
             delete=delete,
             lastdata=lastdata,
-            lastwindow=lastwindow,
+            lastwindow=None,
         )
 
         json_report = report.to_json()
@@ -128,10 +128,10 @@ def compute(
         lastbad = badevents[key]
         lastkey = key
 
-    for k, v in reportswindow.items():
+    for key, value in reportswindow.items():
         if exporters is not None and do_export is True:
-            errors = export(v, exporters)
-            v["errors"].extend(errors)
+            errors = export(value, exporters)
+            reportswindow[key]["errors"].extend(errors)
 
     end = time.time()
     run_duration = round(end - start, 1)

--- a/slo_generator/compute.py
+++ b/slo_generator/compute.py
@@ -128,10 +128,10 @@ def compute(
         lastbad = badevents[key]
         lastkey = key
 
-    for key, value in reportswindow.items():
+    for window, report in reportswindow.items():
         if exporters is not None and do_export is True:
-            errors = export(value, exporters)
-            reportswindow[key]["errors"].extend(errors)
+            errors = export(report, exporters)
+            report["errors"].extend(errors)
 
     end = time.time()
     run_duration = round(end - start, 1)

--- a/slo_generator/compute.py
+++ b/slo_generator/compute.py
@@ -65,11 +65,11 @@ def compute(
     error_budget_policy = utils.get_error_budget_policy(config, spec)
     backend = utils.get_backend(config, spec)
     reports = []
-    badEvents = {}
-    reportsWindow = {}
-    reportsWindowName = {}
-    lastWindow = 0
-    lastData = {}
+    badevents = {}
+    reportswindow = {}
+    reportswindowname = {}
+    lastwindow = 0
+    lastdata = {}
     for step in error_budget_policy["steps"]:
         report = SLOReport(
             config=slo_config,
@@ -78,12 +78,12 @@ def compute(
             timestamp=timestamp,
             client=client,
             delete=delete,
-            lastData=lastData,
-            lastWindow=lastWindow,
+            lastdata=lastdata,
+            lastwindow=lastwindow,
         )
 
         json_report = report.to_json()
-        lastData = report.getLastData()
+        lastdata = report.get_lastdata()
 
         if not report.valid:
             LOGGER.error(report)
@@ -93,14 +93,14 @@ def compute(
         if delete:  # delete mode is enabled
             continue
 
-        window = report.getWindow()
-        lastWindow = window
-        while window in badEvents:
+        window = report.get_window()
+        lastwindow = window
+        while window in badevents:
             window = window + 1
 
-        reportsWindow[window] = json_report
-        badEvents[window] = report.getBadEventsCount()
-        reportsWindowName[window] = report.getWindowName()
+        reportswindow[window] = json_report
+        badevents[window] = report.get_badeventscount()
+        reportswindowname[window] = report.get_windowname()
 
         LOGGER.info(report)
         reports.append(json_report)

--- a/slo_generator/compute.py
+++ b/slo_generator/compute.py
@@ -79,7 +79,7 @@ def compute(
             client=client,
             delete=delete,
             lastdata=lastdata,
-            lastwindow=None,
+            lastwindow=lastwindow,
         )
 
         json_report = report.to_json()

--- a/slo_generator/compute.py
+++ b/slo_generator/compute.py
@@ -119,7 +119,8 @@ def compute(
                     reportsWindow[key]["metadata"]["labels"]["slo_id"]
                 )
             msg = f"{info}"
-            msg += f" | Bad events problem - Window {reportsWindowName[lastKey]} ({badEvents[lastKey]}) "
+            msg += f" | "
+            msg += f"Window {reportsWindowName[lastKey]} ({badEvents[lastKey]}) "
             msg += (
                 "has more bad events than {reportsWindowName[key]} ({badEvents[key]})"
             )

--- a/slo_generator/compute.py
+++ b/slo_generator/compute.py
@@ -123,7 +123,7 @@ def compute(
             msg += (
                 "has more bad events than {reportswindowname[key]} ({badevents[key]})"
             )
-            LOGGER.warn(msg)
+            LOGGER.warning(msg)
             del reportswindow[lastkey]
         lastbad = badevents[key]
         lastkey = key

--- a/slo_generator/compute.py
+++ b/slo_generator/compute.py
@@ -107,28 +107,28 @@ def compute(
 
     lastBad = -1
     lastKey = -1
-    for key in sorted(badEvents):
+    for key in sorted(badevents):
         if lastBad < 0:
-            lastBad = badEvents[key]
+            lastBad = badevents[key]
             lastKey = key
             continue
-        if lastBad > badEvents[key]:
+        if lastBad > badevents[key]:
             info = ""
-            if "slo_id" in reportsWindow[key]["metadata"]["labels"]:
+            if "slo_id" in reportswindow[key]["metadata"]["labels"]:
                 info = "slo_id " + str(
-                    reportsWindow[key]["metadata"]["labels"]["slo_id"]
+                    reportswindow[key]["metadata"]["labels"]["slo_id"]
                 )
             msg = f"{info} | "
-            msg += f"Window {reportsWindowName[lastKey]} ({badEvents[lastKey]}) "
+            msg += f"Window {reportswindowname[lastKey]} ({badevents[lastKey]}) "
             msg += (
                 "has more bad events than {reportsWindowName[key]} ({badEvents[key]})"
             )
             LOGGER.warn(msg)
-            del reportsWindow[lastKey]
-        lastBad = badEvents[key]
+            del reportswindow[lastKey]
+        lastBad = badevents[key]
         lastKey = key
 
-    for k, v in reportsWindow.items():
+    for k, v in reportswindow.items():
         if exporters is not None and do_export is True:
             errors = export(v, exporters)
             v["errors"].extend(errors)

--- a/slo_generator/compute.py
+++ b/slo_generator/compute.py
@@ -79,7 +79,8 @@ def compute(
             client=client,
             delete=delete,
             lastData=lastData,
-            lastWindow=lastWindow)
+            lastWindow=lastWindow,
+        )
 
         json_report = report.to_json()
         lastData = report.getLastData()
@@ -95,7 +96,7 @@ def compute(
         window = report.getWindow()
         lastWindow = window
         while window in badEvents:
-            window=window+1
+            window = window + 1
 
         reportsWindow[window] = json_report
         badEvents[window] = report.getBadEventsCount()
@@ -113,18 +114,21 @@ def compute(
             continue
         if lastBad > badEvents[key]:
             info = ""
-            if "slo_id" in reportsWindow[key]['metadata']['labels']:
-                info = "slo_id "+str(reportsWindow[key]['metadata']['labels']['slo_id'])
-            LOGGER.warn(f"{info} | Bad events problem - Window {reportsWindowName[lastKey]} ({badEvents[lastKey]}) has more bad events than {reportsWindowName[key]} ({badEvents[key]})")
+            if "slo_id" in reportsWindow[key]["metadata"]["labels"]:
+                info = "slo_id " + str(
+                    reportsWindow[key]["metadata"]["labels"]["slo_id"]
+                )
+            LOGGER.warn(
+                f"{info} | Bad events problem - Window {reportsWindowName[lastKey]} ({badEvents[lastKey]}) has more bad events than {reportsWindowName[key]} ({badEvents[key]})"
+            )
             del reportsWindow[lastKey]
         lastBad = badEvents[key]
         lastKey = key
 
-    for k,v in reportsWindow.items():
+    for k, v in reportsWindow.items():
         if exporters is not None and do_export is True:
             errors = export(v, exporters)
-            v['errors'].extend(errors)
-
+            v["errors"].extend(errors)
 
     end = time.time()
     run_duration = round(end - start, 1)

--- a/slo_generator/compute.py
+++ b/slo_generator/compute.py
@@ -27,6 +27,7 @@ from slo_generator.report import SLOReport
 
 LOGGER = logging.getLogger(__name__)
 
+
 # pylint: disable=too-many-arguments,too-many-locals,R0915
 def compute(
     slo_config: dict,

--- a/slo_generator/compute.py
+++ b/slo_generator/compute.py
@@ -118,9 +118,10 @@ def compute(
                 info = "slo_id " + str(
                     reportsWindow[key]["metadata"]["labels"]["slo_id"]
                 )
-            LOGGER.warn(
-                f"{info} | Bad events problem - Window {reportsWindowName[lastKey]} ({badEvents[lastKey]}) has more bad events than {reportsWindowName[key]} ({badEvents[key]})"
-            )
+            msg = f"{info}"
+            msg += f" | Bad events problem - Window {reportsWindowName[lastKey]} ({badEvents[lastKey]}) "
+            msg += "has more bad events than {reportsWindowName[key]} ({badEvents[key]})"
+            LOGGER.warn(msg)
             del reportsWindow[lastKey]
         lastBad = badEvents[key]
         lastKey = key

--- a/slo_generator/compute.py
+++ b/slo_generator/compute.py
@@ -105,28 +105,28 @@ def compute(
         LOGGER.info(report)
         reports.append(json_report)
 
-    lastBad = -1
-    lastKey = -1
+    lastbad = -1
+    lastkey = -1
     for key in sorted(badevents):
-        if lastBad < 0:
-            lastBad = badevents[key]
-            lastKey = key
+        if lastbad < 0:
+            lastbad = badevents[key]
+            lastkey = key
             continue
-        if lastBad > badevents[key]:
+        if lastbad > badevents[key]:
             info = ""
             if "slo_id" in reportswindow[key]["metadata"]["labels"]:
                 info = "slo_id " + str(
                     reportswindow[key]["metadata"]["labels"]["slo_id"]
                 )
             msg = f"{info} | "
-            msg += f"Window {reportswindowname[lastKey]} ({badevents[lastKey]}) "
+            msg += f"Window {reportswindowname[lastkey]} ({badevents[lastkey]}) "
             msg += (
-                "has more bad events than {reportsWindowName[key]} ({badEvents[key]})"
+                "has more bad events than {reportswindowname[key]} ({badevents[key]})"
             )
             LOGGER.warn(msg)
-            del reportswindow[lastKey]
-        lastBad = badevents[key]
-        lastKey = key
+            del reportswindow[lastkey]
+        lastbad = badevents[key]
+        lastkey = key
 
     for k, v in reportswindow.items():
         if exporters is not None and do_export is True:

--- a/slo_generator/compute.py
+++ b/slo_generator/compute.py
@@ -120,7 +120,9 @@ def compute(
                 )
             msg = f"{info}"
             msg += f" | Bad events problem - Window {reportsWindowName[lastKey]} ({badEvents[lastKey]}) "
-            msg += "has more bad events than {reportsWindowName[key]} ({badEvents[key]})"
+            msg += (
+                "has more bad events than {reportsWindowName[key]} ({badEvents[key]})"
+            )
             LOGGER.warn(msg)
             del reportsWindow[lastKey]
         lastBad = badEvents[key]

--- a/slo_generator/report.py
+++ b/slo_generator/report.py
@@ -89,7 +89,7 @@ class SLOReport:
     errors: List[str] = field(default_factory=list)
 
     # Last calculated window
-    lastData = {}
+    lastdata = {}
 
     # pylint: disable=too-many-arguments
     def __init__(
@@ -100,7 +100,7 @@ class SLOReport:
         timestamp,
         client=None,
         delete=False,
-        lastData=lastData,
+        lastata=lastata,
         lastWindow=0,
     ):
 
@@ -128,14 +128,14 @@ class SLOReport:
 
         # if last window same as before, reuse data
         if lastWindow == step["window"]:
-            data = lastData
+            data = lastdata
         # otherwise fetch from backend
         else:
             # Get backend results
             data = self.run_backend(config, backend, client=client, delete=delete)
 
         # save data for next window check
-        self.lastData = data
+        self.lastdata = data
 
         if not self._validate(data):
             self.valid = False
@@ -295,16 +295,16 @@ class SLOReport:
             }
         return asdict(self)
 
-    def getWindow(self):
+    def get_window(self):
         return self.window
 
-    def getBadEventsCount(self):
+    def get_badeventscount(self):
         return self.bad_events_count
 
-    def getWindowName(self):
+    def get_windowname(self):
         return self.error_budget_policy_step_name
 
-    def getLastData(self):
+    def get_lastdata(self):
         return self.lastData
 
     # pylint: disable=too-many-return-statements

--- a/slo_generator/report.py
+++ b/slo_generator/report.py
@@ -100,7 +100,7 @@ class SLOReport:
         timestamp,
         client=None,
         delete=False,
-        lastdata=lastdata,
+        lastdata=None,
         lastwindow=0,
     ):
 

--- a/slo_generator/report.py
+++ b/slo_generator/report.py
@@ -92,7 +92,17 @@ class SLOReport:
     lastData = {}
 
     # pylint: disable=too-many-arguments
-    def __init__(self, config, backend, step, timestamp, client=None, delete=False, lastData=lastData, lastWindow=0):
+    def __init__(
+        self,
+        config,
+        backend,
+        step,
+        timestamp,
+        client=None,
+        delete=False,
+        lastData=lastData,
+        lastWindow=0,
+    ):
 
         # Init dataclass fields from SLO config and Error Budget Policy
         spec = config["spec"]
@@ -117,7 +127,7 @@ class SLOReport:
         self.errors = []
 
         # if last window same as before, reuse data
-        if lastWindow == step['window']:
+        if lastWindow == step["window"]:
             data = lastData
         # otherwise fetch from backend
         else:

--- a/slo_generator/report.py
+++ b/slo_generator/report.py
@@ -100,7 +100,7 @@ class SLOReport:
         timestamp,
         client=None,
         delete=False,
-        lastata=lastata,
+        lastdata=lastdata,
         lastWindow=0,
     ):
 

--- a/slo_generator/report.py
+++ b/slo_generator/report.py
@@ -296,15 +296,47 @@ class SLOReport:
         return asdict(self)
 
     def get_window(self):
+        """Returns SLI window size.
+
+        Args:
+            none
+
+        Returns:
+            int: window size in seconds
+        """
         return self.window
 
     def get_badeventscount(self):
+        """Returns window bad events count.
+
+        Args:
+            none
+
+        Returns:
+            int: total number of bad events
+        """
         return self.bad_events_count
 
     def get_windowname(self):
+        """Returns the name of window
+
+        Args:
+            none
+
+        Returns:
+            string: name of the window
+        """
         return self.error_budget_policy_step_name
 
     def get_lastdata(self):
+        """Returns latdata retrieved from backend
+
+        Args:
+            none
+
+        Returns:
+            json: report json
+        """
         return self.lastdata
 
     # pylint: disable=too-many-return-statements

--- a/slo_generator/report.py
+++ b/slo_generator/report.py
@@ -101,7 +101,7 @@ class SLOReport:
         client=None,
         delete=False,
         lastdata=lastdata,
-        lastWindow=0,
+        lastwindow=0,
     ):
 
         # Init dataclass fields from SLO config and Error Budget Policy
@@ -127,7 +127,7 @@ class SLOReport:
         self.errors = []
 
         # if last window same as before, reuse data
-        if lastWindow == step["window"]:
+        if lastwindow == step["window"]:
             data = lastdata
         # otherwise fetch from backend
         else:
@@ -305,7 +305,7 @@ class SLOReport:
         return self.error_budget_policy_step_name
 
     def get_lastdata(self):
-        return self.lastData
+        return self.lastdata
 
     # pylint: disable=too-many-return-statements
     def _validate(self, data) -> bool:


### PR DESCRIPTION

   Due to promtheus increase errors, some time a shorter window will have more bad events than a longer window, which should no happen and will generate a invalid SLI. When this happens, we discard the calculation for the shorter window.
   The patch also reuse the backend data if window is the same, when we have the same window doing calculations for different burning rates