### PR TITLE
ci: `make unit` fails because of a str local date does not corresponding to a timestamp

### DIFF
--- a/tests/unit/backends/test_cloud_monitoring_mql.py
+++ b/tests/unit/backends/test_cloud_monitoring_mql.py
@@ -15,6 +15,7 @@
 # flake8: noqa
 
 import unittest
+from datetime import datetime
 
 from slo_generator.backends.cloud_monitoring_mql import CloudMonitoringMqlBackend
 
@@ -31,13 +32,17 @@ class TestCloudMonitoringMqlBackend(unittest.TestCase):
     || metric.response_code == 200
 """
 
-        enriched_query = """fetch gae_app
+        end_time_str: str = datetime.fromtimestamp(timestamp).strftime(
+            "%Y/%m/%d %H:%M:%S"
+        )
+
+        enriched_query = f"""fetch gae_app
 | metric 'appengine.googleapis.com/http/server/response_count'
 | filter resource.project_id == 'slo-generator-demo'
 | filter
     metric.response_code == 429
     || metric.response_code == 200
-| group_by [] | within 3600s, d'2022/10/28 22:10:15' | every 3600s"""
+| group_by [] | within 3600s, d'{end_time_str}' | every 3600s"""
 
         assert (
             CloudMonitoringMqlBackend.enrich_query_with_time_horizon_and_period(


### PR DESCRIPTION
Hello,

By executing : 
```
$ make unit
```

I get the error in the output : 
```
Cleaning up distutils stuff
rm -rf build
rm -rf dist
rm -rf MANIFEST
rm -rf *.egg-info
Cleaning up byte compiled python stuff
find . -type f -regex ".*\.py[co]$" -delete
Cleaning up doc builds
rm -rf docs/_build
rm -rf docs/api_modules
rm -rf docs/client_modules
Cleaning up test reports
rm -rf report/*
pytest --cov=slo_generator tests -p no:warnings
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.7.7, pytest-7.2.1, pluggy-1.0.0
rootdir: /home/test/slo-generator
plugins: cov-4.0.0
collected 48 items                                                                                                                                                                                                                           

tests/unit/test_cli.py .....                                                                                                                                                                                                           [ 10%]
tests/unit/test_compute.py ....................                                                                                                                                                                                        [ 52%]
tests/unit/test_migrate.py .                                                                                                                                                                                                           [ 54%]
tests/unit/test_report.py ...........                                                                                                                                                                                                  [ 77%]
tests/unit/test_utils.py ......                                                                                                                                                                                                        [ 89%]
tests/unit/backends/test_cloud_monitoring_mql.py F                                                                                                                                                                                     [ 91%]
tests/unit/backends/test_elasticsearch.py ....                                                                                                                                                                                         [100%]

================================================================================================================== FAILURES ==================================================================================================================
________________________________________________________________________________ TestCloudMonitoringMqlBackend.test_enrich_query_with_time_horizon_and_period ________________________________________________________________________________

self = <tests.unit.backends.test_cloud_monitoring_mql.TestCloudMonitoringMqlBackend testMethod=test_enrich_query_with_time_horizon_and_period>

        def test_enrich_query_with_time_horizon_and_period(self):
            timestamp: float = 1666995015.5144777  # = 2022/10/28 22:10:15.5144777
            window: int = 3600  # in seconds
            query: str = """fetch gae_app
    | metric 'appengine.googleapis.com/http/server/response_count'
    | filter resource.project_id == 'slo-generator-demo'
    | filter
        metric.response_code == 429
        || metric.response_code == 200
    """
    
            enriched_query = """fetch gae_app
    | metric 'appengine.googleapis.com/http/server/response_count'
    | filter resource.project_id == 'slo-generator-demo'
    | filter
        metric.response_code == 429
        || metric.response_code == 200
    | group_by [] | within 3600s, d'2022/10/28 22:10:15' | every 3600s"""
    
>           assert (
                CloudMonitoringMqlBackend.enrich_query_with_time_horizon_and_period(
                    timestamp, window, query
                )
                == enriched_query
            )
E           AssertionError: assert 'fetch gae_ap...| every 3600s' == 'fetch gae_ap...| every 3600s'
E             Skipping 237 identical leading characters in diff, use -v to show
E             - '2022/10/28 22:10:15' | every 3600s
E             ?           ^^^^
E             + '2022/10/29 00:10:15' | every 3600s
E             ?           ^^^^

tests/unit/backends/test_cloud_monitoring_mql.py:42: AssertionError

----------- coverage: platform linux, python 3.7.7-final-0 -----------
Name                                                 Stmts   Miss  Cover
------------------------------------------------------------------------
slo_generator/__init__.py                                0      0   100%
slo_generator/api/__init__.py                            0      0   100%
slo_generator/api/main.py                               99     99     0%
slo_generator/backends/__init__.py                       0      0   100%
slo_generator/backends/cloud_monitoring.py             101     14    86%
slo_generator/backends/cloud_monitoring_mql.py          95     65    32%
slo_generator/backends/cloud_service_monitoring.py     292    186    36%
slo_generator/backends/datadog.py                       86     10    88%
slo_generator/backends/dynatrace.py                    126     42    67%
slo_generator/backends/elasticsearch.py                 62     10    84%
slo_generator/backends/prometheus.py                    82      8    90%
slo_generator/cli.py                                    69     10    86%
slo_generator/compute.py                                81      8    90%
slo_generator/constants.py                              32      0   100%
slo_generator/exporters/__init__.py                      0      0   100%
slo_generator/exporters/base.py                         66      9    86%
slo_generator/exporters/bigquery.py                     88     16    82%
slo_generator/exporters/cloud_monitoring.py             29      0   100%
slo_generator/exporters/cloudevent.py                   28     28     0%
slo_generator/exporters/datadog.py                      19      0   100%
slo_generator/exporters/dynatrace.py                    40      7    82%
slo_generator/exporters/prometheus.py                   35      6    83%
slo_generator/exporters/prometheus_self.py              27     13    52%
slo_generator/exporters/pubsub.py                       14      0   100%
slo_generator/migrations/__init__.py                     0      0   100%
slo_generator/migrations/migrator.py                   222    134    40%
slo_generator/report.py                                188     37    80%
slo_generator/utils.py                                 201     62    69%
------------------------------------------------------------------------
TOTAL                                                 2082    764    63%

========================================================================================================== short test summary info ===========================================================================================================
FAILED tests/unit/backends/test_cloud_monitoring_mql.py::TestCloudMonitoringMqlBackend::test_enrich_query_with_time_horizon_and_period - AssertionError: assert 'fetch gae_ap...| every 3600s' == 'fetch gae_ap...| every 3600s'
======================================================================================================= 1 failed, 47 passed in 46.83s ========================================================================================================
make: *** [Makefile:69: unit] Error 1
```

Because that function returns in part of text the local date corresponding to the POSIX timestamp passed as parameter : https://github.com/google/slo-generator/blob/master/tests/unit/backends/test_cloud_monitoring_mql.py#L43

whereas here the date is set as fixed str in a text : https://github.com/google/slo-generator/blob/master/tests/unit/backends/test_cloud_monitoring_mql.py#L40

So the assert fail, depending of the local env.

How to reproduce : 

OK:
```
$ TZ='UTC' make unit
```
Fail:
```
$ TZ='Europe/Paris' make unit
```

Additional informations : 
```
$ timedatectl show --va -p Timezone
Europe/Paris

$ end_date_str='2022/10/28 22:10:15'
$ sec=$(TZ='UTC' date +'%s' -d "$end_date_str")
$ TZ='Europe/Paris' date -d "@$sec" '+%Y:%m:%d %H:%M:%S'
2022:10:29 00:10:15
```

Thanks in advance for feedbacks.
Rgs,