### PR TITLE
Chore(build):fix isort version conflicting with newest poetry release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
   hooks:
     - id: black
 - repo: https://github.com/PyCQA/isort
-  rev: 5.10.1
+  rev: 5.12.0
   hooks:
     - id: isort
 - repo: https://github.com/PyCQA/pylint


### PR DESCRIPTION
Seems a recent release of poetry broke isort.
Upgrade to at least 5.12.0 is required to fix.

Without this, the pre-commit hook is broken

Related link : https://levelup.gitconnected.com/fix-runtimeerror-poetry-isort-5db7c67b60ff
