### PR TITLE
fix: human time must not hard set the timezone

### DIFF
--- a/slo_generator/utils.py
+++ b/slo_generator/utils.py
@@ -200,26 +200,23 @@ def get_human_time(timestamp: int, timezone: Optional[str] = None) -> str:
         timezone (optional): Explicit timezone (e.g: "America/Chicago").
 
     Returns:
-        str: Formatted human-readable date in ISO format (UTC), with
-             time zone added.
+        str: Formatted human-readable date in ISO format.
 
     Example:
-        >>> get_human_time(1565092435, timezone='Europe/Paris')
-        >>> 2019-08-06T11:53:55.000000+02:00
-        which corresponds to the UTC time appended the timezone format
-        to help with display and retrieval of the date localized.
+        >>> get_human_time(1702660513.987654, timezone='Europe/Paris')
+        >>> 2023-12-15T18:15:13.987654+01:00
+        which corresponds to the timestamp in ISO format
     """
     if timezone is not None:  # get timezone from arg
         to_zone = tz.gettz(timezone)
     else:  # auto-detect locale
         to_zone = tz.tzlocal()
-    dt_utc = datetime.utcfromtimestamp(timestamp)
-    dt_tz = dt_utc.replace(tzinfo=to_zone)
-    timeformat = "%Y-%m-%dT%H:%M:%S.%f%z"
-    date_str = datetime.strftime(dt_tz, timeformat)
-    core_str = date_str[:-2]
-    tz_str = date_str[-2:]
-    date_str = f"{core_str}:{tz_str}"
+
+    # NB: as we set tz, dt_tz is an "aware" datetime
+    # see: https://docs.python.org/3/library/datetime.html#aware-and-naive-objects
+    dt_tz = datetime.fromtimestamp(timestamp, tz=to_zone)
+    date_str = dt_tz.isoformat()
+
     return date_str
 
 

--- a/tests/unit/fixtures/slo_report_v2.json
+++ b/tests/unit/fixtures/slo_report_v2.json
@@ -31,7 +31,7 @@
     }
   },
   "sli_measurement": 0.5,
-  "timestamp": 1567762279.287761,
-  "timestamp_human": "2019-09-05 11:55:01.004603 UTC",
+  "timestamp": 1702660513.987654,
+  "timestamp_human": "2023-12-15T18:15:13.987654+01:00",
   "window": 43200
 }

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -25,25 +25,43 @@ from slo_generator.utils import (
 class TestUtils(unittest.TestCase):
     def test_get_human_time(self):
         # Timezones
-        tz_1 = "Europe/Paris"
-        tz_2 = "America/Chicago"
+        tz_UTC = "UTC"
+        tz_Paris = "Europe/Paris"
+        tz_Chicago = "America/Chicago"
 
         # Timestamp 1
-        timestamp = 1565092435
-        utc_time = "2019-08-06T11:53:55.000000"
-        human_paris_1 = get_human_time(timestamp, timezone=tz_1)
-        human_chicago_1 = get_human_time(timestamp, timezone=tz_2)
+        timestamp_20230615T16 = 1686845838
+        utc_time_20230615T16 = "2023-06-15T16:17:18+00:00"
+        paris_time_20230615T16 = "2023-06-15T18:17:18+02:00"
+        chicago_time_20230615T16 = "2023-06-15T11:17:18-05:00"
+        human_utc_20230615T16 = get_human_time(timestamp_20230615T16, timezone=tz_UTC)
+        human_paris_20230615T16 = get_human_time(
+            timestamp_20230615T16, timezone=tz_Paris
+        )
+        human_chicago_20230615T16 = get_human_time(
+            timestamp_20230615T16, timezone=tz_Chicago
+        )
 
         # Timestamp 2
-        timestamp_2 = 1565095633.9568892
-        utc_time_2 = "2019-08-06T12:47:13.956889"
-        human_paris_2 = get_human_time(timestamp_2, timezone=tz_1)
-        human_chicago_2 = get_human_time(timestamp_2, timezone=tz_2)
+        timestamp_20231215T16 = 1702660513.987654
+        utc_time_20231215T16 = "2023-12-15T17:15:13.987654+00:00"
+        paris_time_20231215T16 = "2023-12-15T18:15:13.987654+01:00"
+        chicago_time_20231215T16 = "2023-12-15T11:15:13.987654-06:00"
+        human_utc_20231215T16 = get_human_time(timestamp_20231215T16, timezone=tz_UTC)
+        human_paris_20231215T16 = get_human_time(
+            timestamp_20231215T16, timezone=tz_Paris
+        )
+        human_chicago_20231215T16 = get_human_time(
+            timestamp_20231215T16, timezone=tz_Chicago
+        )
 
-        self.assertEqual(human_paris_1, utc_time + "+02:00")
-        self.assertEqual(human_chicago_1, utc_time + "-05:00")
-        self.assertEqual(human_paris_2, utc_time_2 + "+02:00")
-        self.assertEqual(human_chicago_2, utc_time_2 + "-05:00")
+        self.assertEqual(utc_time_20230615T16, human_utc_20230615T16)
+        self.assertEqual(paris_time_20230615T16, human_paris_20230615T16)
+        self.assertEqual(chicago_time_20230615T16, human_chicago_20230615T16)
+
+        self.assertEqual(utc_time_20231215T16, human_utc_20231215T16)
+        self.assertEqual(paris_time_20231215T16, human_paris_20231215T16)
+        self.assertEqual(chicago_time_20231215T16, human_chicago_20231215T16)
 
     def test_get_backend_cls(self):
         res1 = get_backend_cls("CloudMonitoring")


### PR DESCRIPTION
Hello,

utils.get_human_time() function format a UNIX timestamp as string to be stored into BigQuery.
But it replaces the timezone without dealing with the UTC time.

Using datetime.fromtimestamp() do the job well.

Tests have been updated accordingly.

Regards,
Sébastien
