### PR TITLE
refactor(backends/datadog): avoid useless call to Datadog API

### DIFF
--- a/slo_generator/backends/datadog.py
+++ b/slo_generator/backends/datadog.py
@@ -21,6 +21,8 @@ import pprint
 
 import datadog
 
+from slo_generator import utils
+
 LOGGER = logging.getLogger(__name__)
 logging.getLogger("datadog.api").setLevel(logging.ERROR)
 
@@ -124,8 +126,9 @@ class DatadogBackend:
         """
         slo_id = slo_config["spec"]["service_level_indicator"]["slo_id"]
         from_ts = timestamp - window
-        slo_data = self.client.ServiceLevelObjective.get(id=slo_id)
-        LOGGER.debug(f"SLO data: {slo_id} | Result: {pprint.pformat(slo_data)}")
+        if utils.is_debug_enabled():
+            slo_data = self.client.ServiceLevelObjective.get(id=slo_id)
+            LOGGER.debug(f"SLO data: {slo_id} | Result: {pprint.pformat(slo_data)}")
         data = self.client.ServiceLevelObjective.history(
             id=slo_id,
             from_ts=from_ts,

--- a/slo_generator/utils.py
+++ b/slo_generator/utils.py
@@ -168,9 +168,14 @@ def parse_config(
     return data
 
 
+def is_debug_enabled():
+    """Check if DEBUG mode is enabled."""
+    return DEBUG == 1
+
+
 def setup_logging():
     """Setup logging for the CLI."""
-    if DEBUG == 1:
+    if is_debug_enabled():
         print(f"DEBUG mode is enabled. DEBUG={DEBUG}")
         level = logging.DEBUG
         format_str = "%(name)s - %(levelname)s - %(message)s"


### PR DESCRIPTION
Hello,

Perf improvement. Avoid calling `/slo` endpoint because the response is not used.

As discussed, I left the call but I added a condition to run it only in debug mode. 
NB: SLO's data are available in the `/slo/history` endpoint call right after this one

Regards,
Sébastien
