### PR TITLE
refactor(tests): allow to setup the Datadog host URL

### DIFF
--- a/samples/config.yaml
+++ b/samples/config.yaml
@@ -10,6 +10,7 @@ backends:
     project_id: ${STACKDRIVER_HOST_PROJECT_ID}
   samples.custom.custom_backend.CustomBackend: {}
   datadog:
+    api_host: ${DATADOG_API_HOST}
     api_key: ${DATADOG_API_KEY}
     app_key: ${DATADOG_APP_KEY}
   dynatrace:

--- a/tests/unit/test_stubs.py
+++ b/tests/unit/test_stubs.py
@@ -50,6 +50,7 @@ CTX = {
     "BIGQUERY_TABLE_ID": "fake",
     "BIGQUERY_DATASET_ID": "fake",
     "BIGQUERY_TABLE_NAME": "fake",
+    "DATADOG_API_HOST": "fake",
     "DATADOG_API_KEY": "fake",
     "DATADOG_APP_KEY": "fake",
     "DATADOG_SLO_ID": "fake",


### PR DESCRIPTION
For local tests purposes, we may want to update the Datadog host URL used for Datadog API requests.

Example: testing rate limiting
Running a local NginX server acting as a Datadog API mock. We can set a dedicated rate-limit config without burning our Datadog instance (called "organization" by Datadog) quota.

Reminder: https://docs.datadoghq.com/api/latest/rate-limits/
