### PR TITLE
fix(open_search): change the way range is added to filters

### DIFF
--- a/slo_generator/backends/open_search.py
+++ b/slo_generator/backends/open_search.py
@@ -150,7 +150,6 @@ class OpenSearchBackend:
             body["query"]["bool"]["filter"].append({"range": range_query})
         else:
             body["query"]["bool"]["filter"] = {"range": range_query}
-        print(body)
         return body
 
 

--- a/slo_generator/backends/open_search.py
+++ b/slo_generator/backends/open_search.py
@@ -134,7 +134,7 @@ class OpenSearchBackend:
         }
 
         if "filter" in body["query"]["bool"]:
-            body["query"]["bool"]["filter"]["range"] = range_query
+            body["query"]["bool"]["filter"].append({"range": range_query})
         else:
             body["query"]["bool"]["filter"] = {"range": range_query}
 

--- a/slo_generator/backends/open_search.py
+++ b/slo_generator/backends/open_search.py
@@ -6,6 +6,8 @@ Opensearch backend implementation.
 import copy
 import logging
 
+from opensearchpy import OpenSearch
+
 from slo_generator.constants import NO_DATA
 
 LOGGER = logging.getLogger(__name__)
@@ -34,7 +36,7 @@ class OpenSearchBackend:
             if api_key:
                 conf["api_key"] = (api_key["id"], api_key["value"])
 
-            # self.client = OpenSearch(**conf)
+            self.client = OpenSearch(**conf)
 
     # pylint: disable=unused-argument
     def good_bad_ratio(self, timestamp, window, slo_config):

--- a/tests/unit/backends/test_opensearch.py
+++ b/tests/unit/backends/test_opensearch.py
@@ -63,17 +63,21 @@ class TestOpenSearchBackend(unittest.TestCase):
                             "status": "200",
                         },
                     },
-                    "filter": {
-                        "term": {
-                            "type": "get",
+                    "filter": [
+                        {
+                            "term": {
+                                "type": "get",
+                            }
                         },
-                        "range": {
-                            "date": {
-                                "gte": "now-3600s/s",
-                                "lt": "now/s",
-                            },
+                        {
+                            "range": {
+                                "date": {
+                                    "gte": "now-3600s/s",
+                                    "lt": "now/s",
+                                },
+                            }
                         },
-                    },
+                    ],
                 },
             },
             "track_total_hits": True,
@@ -81,7 +85,7 @@ class TestOpenSearchBackend(unittest.TestCase):
 
         assert OpenSearchBackend.build_query(query, 3600, "date") == enriched_query
 
-    def test_build_query_with_simple_query_and_existing_filter_with_range(self):
+    def test_build_query_with_simple_query_and_existing_filter_on_range_date(self):
         query: dict = {
             "must": {
                 "term": {
@@ -106,14 +110,64 @@ class TestOpenSearchBackend(unittest.TestCase):
                             "status": "200",
                         },
                     },
-                    "filter": {
-                        "range": {
-                            "date": {
-                                "gte": "now-3600s/s",
-                                "lt": "now/s",
+                    "filter": [
+                        {
+                            "range": {
+                                "date": {
+                                    "gte": "now-3600s/s",
+                                    "lt": "now/s",
+                                },
                             },
+                        }
+                    ],
+                },
+            },
+            "track_total_hits": True,
+        }
+
+        assert OpenSearchBackend.build_query(query, 3600, "date") == enriched_query
+
+    def test_build_query_with_simple_query_and_existing_filter_with_range(self):
+        query: dict = {
+            "must": {
+                "term": {
+                    "status": "200",
+                },
+            },
+            "filter": {
+                "range": {
+                    "status": {
+                        "lt": "299",
+                    },
+                },
+            },
+        }
+
+        enriched_query: dict = {
+            "query": {
+                "bool": {
+                    "must": {
+                        "term": {
+                            "status": "200",
                         },
                     },
+                    "filter": [
+                        {
+                            "range": {
+                                "status": {
+                                    "lt": "299",
+                                }
+                            }
+                        },
+                        {
+                            "range": {
+                                "date": {
+                                    "gte": "now-3600s/s",
+                                    "lt": "now/s",
+                                },
+                            }
+                        },
+                    ],
                 },
             },
             "track_total_hits": True,


### PR DESCRIPTION
-- Actual Behaviour -- 

When using the open_search backend you cannot use filters in the query.


```
backend: open_search
error_budget_policy: 28days
method: good_bad_ratio
service_level_indicator:
    index: "gravitee-request-*"
    date_field: '@timestamp'
    query_good:
        filter:
            - match:
                api: some-data
            - range:
                status:
                    gte: 200
                    lt: 299
    query_bad:
        filter:
            - match:
                api: some-data
        must_not:
            range:
                status:
                    lt: 299
goal: 0.99

```
    
The backend will throw the following error `TypeError: list indices must be integers or slices, not str`
    
-- Fix -- 

To avoid this error we must use append instead of directly assigning range = range_query (Furthermore, even if the actual code was working it would erase any range filter made in the yaml without informing the user which could have bring confusion).
