### PR TITLE
fix(ci): publish to PyPI with a Truster Publisher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,3 @@ jobs:
 
       - name: Release PyPI package
         run: make deploy
-        env:
-          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_REPOSITORY_URL: https://upload.pypi.org/legacy/


### PR DESCRIPTION
The username/password pair authentication method is obsolete now that 2FA is enforced since Jan 1, 2024.