### PR TITLE
Included additional metrics to be exposed. Only 6/7 metrics are being exposed if I am using the promethues as a backend and the pushgateway as an exporter.

### DIFF
--- a/slo_generator/exporters/base.py
+++ b/slo_generator/exporters/base.py
@@ -29,6 +29,7 @@ DEFAULT_METRIC_LABELS = [
     "feature_name",
     "slo_name",
     "metadata",
+    "error_budget_minutes",
 ]
 
 # Default metrics that are exported by metrics exporters.
@@ -55,6 +56,11 @@ DEFAULT_METRICS = [
     },
     {
         "name": "slo_target",
+        "description": "Service Level Objective target.",
+        "labels": DEFAULT_METRIC_LABELS,
+    },
+    {
+        "name": "error_budget_minutes",
         "description": "Service Level Objective target.",
         "labels": DEFAULT_METRIC_LABELS,
     },

--- a/slo_generator/report.py
+++ b/slo_generator/report.py
@@ -405,7 +405,8 @@ class SLOReport:
             "BR: {error_budget_burn_rate:<2} / "
             "{error_budget_burn_rate_threshold} | "
             "Alert: {alert:<1} | Good: {good_events_count:<8} | "
-            "Bad: {bad_events_count:<8}"
+            "Bad: {bad_events_count:<8} | "
+            "Remaining Minutes:{error_budget_remaining_minutes:<8} | Error Minutes : {error_minutes:<8} | "
         ).format_map(report)
         full_str = f"{self.info} | {sli_str} | {result_str}"
         if COLORED_OUTPUT == 1:


### PR DESCRIPTION
I have made changes to the files in base.py and report.py to ensure that additional metrics namely (error_budget_target, error_budget_measurement, error_budget_burn_rate, error_budget_remaining_minutes, error_budget_minutes etc) be exposed. But i am not sure if these changes are actually being compiled and executed as the changes in the source code arent reflecting in the output.