### PR TITLE
feat(opensearch): Performance optimization using count instead of search

### DIFF
--- a/slo_generator/backends/open_search.py
+++ b/slo_generator/backends/open_search.py
@@ -87,7 +87,7 @@ class OpenSearchBackend:
         Returns:
             dict: Response.
         """
-        return self.client.search(index=index, body=body)
+        return self.client.count(index=index, body=body)
 
     @staticmethod
     def count(response):
@@ -100,7 +100,7 @@ class OpenSearchBackend:
             int: Event count.
         """
         try:
-            return response["hits"]["total"]["value"]
+            return response["count"]
         except KeyError as exception:
             LOGGER.warning("Couldn't find any values in timeseries response")
             LOGGER.debug(exception, exc_info=True)
@@ -123,7 +123,7 @@ class OpenSearchBackend:
         """
         if query is None:
             return None
-        body = {"query": {"bool": query}, "track_total_hits": True}
+        body = {"query": {"bool": query}}
         range_query = {
             f"{date_field}": {
                 "gte": f"now-{window}s/s",

--- a/tests/unit/backends/test_opensearch.py
+++ b/tests/unit/backends/test_opensearch.py
@@ -33,8 +33,7 @@ class TestOpenSearchBackend(unittest.TestCase):
                         },
                     },
                 },
-            },
-            "track_total_hits": True,
+            }
         }
 
         assert OpenSearchBackend.build_query(query, 3600, "date") == enriched_query
@@ -77,8 +76,7 @@ class TestOpenSearchBackend(unittest.TestCase):
                         },
                     ],
                 },
-            },
-            "track_total_hits": True,
+            }
         }
 
         assert OpenSearchBackend.build_query(query, 3600, "date") == enriched_query
@@ -119,8 +117,7 @@ class TestOpenSearchBackend(unittest.TestCase):
                         }
                     ],
                 },
-            },
-            "track_total_hits": True,
+            }
         }
 
         assert OpenSearchBackend.build_query(query, 3600, "date") == enriched_query
@@ -167,8 +164,7 @@ class TestOpenSearchBackend(unittest.TestCase):
                         },
                     ],
                 },
-            },
-            "track_total_hits": True,
+            }
         }
 
         assert OpenSearchBackend.build_query(query, 3600, "date") == enriched_query


### PR DESCRIPTION
Everything is in the title but I will add a bit of details, 

While trying to find a way to optimize opensearch query time, I came accross the fact that we're using search endpoint but only using the result of `[“hits”][“total”][“value”]`. 

Meaning that we're consuming (a lot ?) of memory/time to calculate the _score and _ranking while not using it. 

So I switch it towards the count endpoint. Unfortunately it's quite hard to find documentation with precise benchmark of those to APIs, furthermore with intern request caching of Opensearch, even testing it manually can become quite a struggle. 

But in the end, it doesn't make sense to use the search endpoint if we just need to count. 

PS: Also we also weren't using the size: 0 with the search and that's definitely inducing performance issue. 