### PR TITLE
:fire: Drop non necessary part of config from short snippet

### DIFF
--- a/docs/providers/cloud_monitoring.md
+++ b/docs/providers/cloud_monitoring.md
@@ -122,8 +122,6 @@ In Cloud Monitoring, there are three different ways to specify bucket boundaries
   ```yaml
   backend: cloud_monitoring_mql
   method: distribution_cut
-  exporters:
-  - cloud_monitoring
   service_level_indicator:
     filter_valid: >
       fetch https_lb_rule


### PR DESCRIPTION
In other page snippets there is omitted "exporters" config key - it can be found in full snippet after visit full config link