### PR TITLE
fix: Prometheus client missing time argument

### DIFF
--- a/slo_generator/api/main.py
+++ b/slo_generator/api/main.py
@@ -211,7 +211,7 @@ def process_batch_req(request, data, config):
     for url in urls:
         if "pubsub_batch_handler" in config:
             LOGGER.info(f"Sending {url} to pubsub batch handler.")
-            from google.cloud import pubsub_v1  # noqa: PLC0415
+            from google.cloud import pubsub_v1
 
             # pytype: disable=attribute-error
 

--- a/slo_generator/api/main.py
+++ b/slo_generator/api/main.py
@@ -211,7 +211,7 @@ def process_batch_req(request, data, config):
     for url in urls:
         if "pubsub_batch_handler" in config:
             LOGGER.info(f"Sending {url} to pubsub batch handler.")
-            from google.cloud import pubsub_v1
+            from google.cloud import pubsub_v1  # noqa: PLC0415
 
             # pytype: disable=attribute-error
 

--- a/slo_generator/backends/cloud_monitoring_mql.py
+++ b/slo_generator/backends/cloud_monitoring_mql.py
@@ -15,6 +15,7 @@
 `cloud_monitoring_mql.py`
 Cloud Monitoring backend implementation with MQL (Monitoring Query Language).
 """
+# ruff: noqa: UP045
 
 import logging
 import pprint

--- a/slo_generator/backends/cloud_monitoring_mql.py
+++ b/slo_generator/backends/cloud_monitoring_mql.py
@@ -18,11 +18,9 @@ Cloud Monitoring backend implementation with MQL (Monitoring Query Language).
 
 import logging
 import pprint
-import typing
 import warnings
 from collections import OrderedDict
 from datetime import datetime, timezone
-from typing import Optional
 
 from google.api.distribution_pb2 import Distribution
 from google.cloud.monitoring_v3 import QueryTimeSeriesRequest
@@ -74,8 +72,8 @@ class CloudMonitoringMqlBackend:
         """
         measurement: dict = slo_config["spec"]["service_level_indicator"]
         filter_good: str = measurement["filter_good"]
-        filter_bad: Optional[str] = measurement.get("filter_bad")
-        filter_valid: Optional[str] = measurement.get("filter_valid")
+        filter_bad: str | None = measurement.get("filter_bad")
+        filter_valid: str | None = measurement.get("filter_valid")
 
         # Query 'good events' timeseries
         good_ts: list[TimeSeries] = self.query(timestamp, window, filter_good)
@@ -115,7 +113,7 @@ class CloudMonitoringMqlBackend:
         measurement: dict = slo_config["spec"]["service_level_indicator"]
         filter_valid: str = measurement["filter_valid"]
         threshold_bucket: int = int(measurement["threshold_bucket"])
-        good_below_threshold: typing.Optional[bool] = measurement.get(
+        good_below_threshold: bool | None = measurement.get(
             "good_below_threshold", True
         )
 

--- a/slo_generator/backends/cloud_monitoring_mql.py
+++ b/slo_generator/backends/cloud_monitoring_mql.py
@@ -18,9 +18,11 @@ Cloud Monitoring backend implementation with MQL (Monitoring Query Language).
 
 import logging
 import pprint
+import typing
 import warnings
 from collections import OrderedDict
 from datetime import datetime, timezone
+from typing import Optional
 
 from google.api.distribution_pb2 import Distribution
 from google.cloud.monitoring_v3 import QueryTimeSeriesRequest
@@ -72,8 +74,8 @@ class CloudMonitoringMqlBackend:
         """
         measurement: dict = slo_config["spec"]["service_level_indicator"]
         filter_good: str = measurement["filter_good"]
-        filter_bad: str | None = measurement.get("filter_bad")
-        filter_valid: str | None = measurement.get("filter_valid")
+        filter_bad: Optional[str] = measurement.get("filter_bad")
+        filter_valid: Optional[str] = measurement.get("filter_valid")
 
         # Query 'good events' timeseries
         good_ts: list[TimeSeries] = self.query(timestamp, window, filter_good)
@@ -113,7 +115,7 @@ class CloudMonitoringMqlBackend:
         measurement: dict = slo_config["spec"]["service_level_indicator"]
         filter_valid: str = measurement["filter_valid"]
         threshold_bucket: int = int(measurement["threshold_bucket"])
-        good_below_threshold: bool | None = measurement.get(
+        good_below_threshold: typing.Optional[bool] = measurement.get(
             "good_below_threshold", True
         )
 

--- a/slo_generator/backends/cloud_service_monitoring.py
+++ b/slo_generator/backends/cloud_service_monitoring.py
@@ -15,6 +15,7 @@
 `cloud_service_monitoring.py`
 Cloud Service Monitoring exporter class.
 """
+# ruff: noqa: UP045,UP007
 
 import difflib
 import json

--- a/slo_generator/backends/cloud_service_monitoring.py
+++ b/slo_generator/backends/cloud_service_monitoring.py
@@ -22,7 +22,6 @@ import logging
 import os
 import warnings
 from collections.abc import Sequence
-from typing import Optional, Union
 
 import google.api_core.exceptions
 from google.cloud.monitoring_v3 import ServiceMonitoringServiceClient
@@ -119,7 +118,7 @@ class CloudServiceMonitoringBackend:
         """
         return self.retrieve_slo(timestamp, window, slo_config)
 
-    def delete(self, timestamp: int, window: int, slo_config: dict) -> Optional[dict]:
+    def delete(self, timestamp: int, window: int, slo_config: dict) -> dict | None:
         """Delete method.
 
         Args:
@@ -221,7 +220,7 @@ class CloudServiceMonitoringBackend:
         )
         return SSM.to_json(service)
 
-    def get_service(self, slo_config: dict) -> Optional[dict]:
+    def get_service(self, slo_config: dict) -> dict | None:
         """Get Service object from Cloud Service Monitoring API.
 
         Args:
@@ -282,7 +281,7 @@ class CloudServiceMonitoringBackend:
     def build_service_id(
         self,
         slo_config: dict,
-        dest_project_id: Optional[str] = None,
+        dest_project_id: str | None = None,
         full: bool = False,
     ):
         """Build service id from SLO configuration.
@@ -479,7 +478,7 @@ class CloudServiceMonitoringBackend:
             raise ValueError(f'Method "{method}" is not supported.')
         return slo
 
-    def get_slo(self, window: int, slo_config: dict) -> Optional[dict]:
+    def get_slo(self, window: int, slo_config: dict) -> dict | None:
         """Get SLO object from Cloud Service Monssitoring API.
 
         Args:
@@ -555,7 +554,7 @@ class CloudServiceMonitoringBackend:
         # LOGGER.debug(slos)
         return [SSM.to_json(slo) for slo in slos]
 
-    def delete_slo(self, window: int, slo_config: dict) -> Optional[dict]:
+    def delete_slo(self, window: int, slo_config: dict) -> dict | None:
         """Delete SLO from Cloud Service Monitoring API.
 
         Args:
@@ -634,9 +633,7 @@ class CloudServiceMonitoringBackend:
         return local_json == remote_json
 
     @staticmethod
-    def string_diff(
-        string1: Union[str, Sequence[str]], string2: Union[str, Sequence[str]]
-    ) -> list:
+    def string_diff(string1: str | Sequence[str], string2: str | Sequence[str]) -> list:
         """Diff 2 strings. Used to print comparison of JSONs for debugging.
 
         Args:

--- a/slo_generator/backends/cloud_service_monitoring.py
+++ b/slo_generator/backends/cloud_service_monitoring.py
@@ -22,6 +22,7 @@ import logging
 import os
 import warnings
 from collections.abc import Sequence
+from typing import Optional, Union
 
 import google.api_core.exceptions
 from google.cloud.monitoring_v3 import ServiceMonitoringServiceClient
@@ -118,7 +119,7 @@ class CloudServiceMonitoringBackend:
         """
         return self.retrieve_slo(timestamp, window, slo_config)
 
-    def delete(self, timestamp: int, window: int, slo_config: dict) -> dict | None:
+    def delete(self, timestamp: int, window: int, slo_config: dict) -> Optional[dict]:
         """Delete method.
 
         Args:
@@ -220,7 +221,7 @@ class CloudServiceMonitoringBackend:
         )
         return SSM.to_json(service)
 
-    def get_service(self, slo_config: dict) -> dict | None:
+    def get_service(self, slo_config: dict) -> Optional[dict]:
         """Get Service object from Cloud Service Monitoring API.
 
         Args:
@@ -281,7 +282,7 @@ class CloudServiceMonitoringBackend:
     def build_service_id(
         self,
         slo_config: dict,
-        dest_project_id: str | None = None,
+        dest_project_id: Optional[str] = None,
         full: bool = False,
     ):
         """Build service id from SLO configuration.
@@ -478,7 +479,7 @@ class CloudServiceMonitoringBackend:
             raise ValueError(f'Method "{method}" is not supported.')
         return slo
 
-    def get_slo(self, window: int, slo_config: dict) -> dict | None:
+    def get_slo(self, window: int, slo_config: dict) -> Optional[dict]:
         """Get SLO object from Cloud Service Monssitoring API.
 
         Args:
@@ -554,7 +555,7 @@ class CloudServiceMonitoringBackend:
         # LOGGER.debug(slos)
         return [SSM.to_json(slo) for slo in slos]
 
-    def delete_slo(self, window: int, slo_config: dict) -> dict | None:
+    def delete_slo(self, window: int, slo_config: dict) -> Optional[dict]:
         """Delete SLO from Cloud Service Monitoring API.
 
         Args:
@@ -633,7 +634,9 @@ class CloudServiceMonitoringBackend:
         return local_json == remote_json
 
     @staticmethod
-    def string_diff(string1: str | Sequence[str], string2: str | Sequence[str]) -> list:
+    def string_diff(
+        string1: Union[str, Sequence[str]], string2: Union[str, Sequence[str]]
+    ) -> list:
         """Diff 2 strings. Used to print comparison of JSONs for debugging.
 
         Args:

--- a/slo_generator/backends/prometheus.py
+++ b/slo_generator/backends/prometheus.py
@@ -20,7 +20,6 @@ import json
 import logging
 import os
 import pprint
-from typing import Optional, Union
 
 from prometheus_http_client import Prometheus
 
@@ -141,9 +140,9 @@ class PrometheusBackend:
         self,
         filter: str,
         window: int,
-        timestamp: Optional[int] = None,
-        operators: Union[list, None] = None,
-        labels: Union[dict, None] = None,
+        timestamp: int | None = None,
+        operators: list | None = None,
+        labels: dict | None = None,
     ) -> dict:
         """Query Prometheus server.
 
@@ -189,8 +188,8 @@ class PrometheusBackend:
     def _fmt_query(
         query: str,
         window: int,
-        operators: Union[list[str], None] = None,
-        labels: Union[dict[str, str], None] = None,
+        operators: list[str] | None = None,
+        labels: dict[str, str] | None = None,
     ) -> str:
         """Format Prometheus query:
 

--- a/slo_generator/backends/prometheus.py
+++ b/slo_generator/backends/prometheus.py
@@ -20,6 +20,7 @@ import json
 import logging
 import os
 import pprint
+from typing import Optional, Union
 
 from prometheus_http_client import Prometheus
 
@@ -140,9 +141,9 @@ class PrometheusBackend:
         self,
         filter: str,
         window: int,
-        timestamp: int | None = None,
-        operators: list | None = None,
-        labels: dict | None = None,
+        timestamp: Optional[int] = None,
+        operators: Union[list, None] = None,
+        labels: Union[dict, None] = None,
     ) -> dict:
         """Query Prometheus server.
 
@@ -188,8 +189,8 @@ class PrometheusBackend:
     def _fmt_query(
         query: str,
         window: int,
-        operators: list[str] | None = None,
-        labels: dict[str, str] | None = None,
+        operators: Union[list[str], None] = None,
+        labels: Union[dict[str, str], None] = None,
     ) -> str:
         """Format Prometheus query:
 

--- a/slo_generator/backends/prometheus.py
+++ b/slo_generator/backends/prometheus.py
@@ -163,7 +163,7 @@ class PrometheusBackend:
             labels = {}
         filter = PrometheusBackend._fmt_query(filter, window, operators, labels)
         LOGGER.debug(f"Query: {filter}")
-        response = self.client.query(metric=filter)
+        response = self.client.query(metric=filter, time=timestamp)
         response = json.loads(response)
         LOGGER.debug(pprint.pformat(response))
         return response

--- a/slo_generator/backends/prometheus.py
+++ b/slo_generator/backends/prometheus.py
@@ -15,6 +15,7 @@
 `prometheus.py`
 Prometheus backend implementation.
 """
+# ruff: noqa: UP045,UP007
 
 import json
 import logging

--- a/slo_generator/backends/prometheus.py
+++ b/slo_generator/backends/prometheus.py
@@ -118,6 +118,7 @@ class PrometheusBackend:
         res_good = self.query(
             expr,
             window,
+            timestamp=timestamp,
             operators=["increase", "sum"],
             labels=labels,
         )
@@ -131,6 +132,7 @@ class PrometheusBackend:
         res_valid = self.query(
             expr_count,
             window,
+            timestamp=timestamp,
             operators=["increase", "sum"],
         )
         valid_count = PrometheusBackend.count(res_valid)

--- a/slo_generator/cli.py
+++ b/slo_generator/cli.py
@@ -166,7 +166,7 @@ def compute(slo_config, config, export, delete, timestamp):
 def api(ctx, config, exporters, signature_type, target, port):  # noqa: PLR0913
     """Run an API that can receive requests (supports both 'http' and
     'cloudevents' signature types)."""
-    from functions_framework._cli import _cli
+    from functions_framework._cli import _cli  # noqa: PLC0415
 
     os.environ["EXPORTERS"] = exporters
     os.environ["CONFIG_PATH"] = config

--- a/slo_generator/cli.py
+++ b/slo_generator/cli.py
@@ -166,7 +166,7 @@ def compute(slo_config, config, export, delete, timestamp):
 def api(ctx, config, exporters, signature_type, target, port):  # noqa: PLR0913
     """Run an API that can receive requests (supports both 'http' and
     'cloudevents' signature types)."""
-    from functions_framework._cli import _cli  # noqa: PLC0415
+    from functions_framework._cli import _cli
 
     os.environ["EXPORTERS"] = exporters
     os.environ["CONFIG_PATH"] = config

--- a/slo_generator/compute.py
+++ b/slo_generator/compute.py
@@ -15,6 +15,7 @@
 `compute.py`
 Compute utilities.
 """
+# ruff: noqa: UP045
 
 import logging
 import pprint

--- a/slo_generator/compute.py
+++ b/slo_generator/compute.py
@@ -19,7 +19,6 @@ Compute utilities.
 import logging
 import pprint
 import time
-from typing import Optional
 
 from slo_generator import constants, utils
 from slo_generator.migrations.migrator import report_v2tov1
@@ -31,7 +30,7 @@ LOGGER = logging.getLogger(__name__)
 def compute(  # noqa: PLR0913
     slo_config: dict,
     config: dict,
-    timestamp: Optional[float] = None,
+    timestamp: float | None = None,
     client=None,
     do_export: bool = False,
     delete: bool = False,

--- a/slo_generator/compute.py
+++ b/slo_generator/compute.py
@@ -19,6 +19,7 @@ Compute utilities.
 import logging
 import pprint
 import time
+from typing import Optional
 
 from slo_generator import constants, utils
 from slo_generator.migrations.migrator import report_v2tov1
@@ -30,7 +31,7 @@ LOGGER = logging.getLogger(__name__)
 def compute(  # noqa: PLR0913
     slo_config: dict,
     config: dict,
-    timestamp: float | None = None,
+    timestamp: Optional[float] = None,
     client=None,
     do_export: bool = False,
     delete: bool = False,

--- a/slo_generator/utils.py
+++ b/slo_generator/utils.py
@@ -15,6 +15,7 @@
 `utils.py`
 Utility functions.
 """
+# ruff: noqa: UP045
 
 import argparse
 import errno
@@ -188,7 +189,7 @@ def setup_logging():
 
     # Ignore Cloud SDK warning when using a user instead of service account
     try:
-        from google.auth._default import _CLOUD_SDK_CREDENTIALS_WARNING
+        from google.auth._default import _CLOUD_SDK_CREDENTIALS_WARNING  # noqa: PLC0415
 
         warnings.filterwarnings("ignore", message=_CLOUD_SDK_CREDENTIALS_WARNING)
     except ImportError:

--- a/slo_generator/utils.py
+++ b/slo_generator/utils.py
@@ -28,6 +28,7 @@ import warnings
 from collections.abc import Mapping
 from datetime import datetime
 from pathlib import Path
+from typing import Optional
 
 import yaml
 from dateutil import tz
@@ -46,7 +47,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 def load_configs(
-    path: str, ctx: os._Environ = os.environ, kind: str | None = None
+    path: str, ctx: os._Environ = os.environ, kind: Optional[str] = None
 ) -> list:
     """Load multiple slo-generator configs from a folder path.
 
@@ -66,8 +67,8 @@ def load_configs(
 
 
 def load_config(
-    path: str, ctx: os._Environ = os.environ, kind: str | None = None
-) -> dict | None:
+    path: str, ctx: os._Environ = os.environ, kind: Optional[str] = None
+) -> Optional[dict]:
     """Load any slo-generator config, from a local path, a GCS URL, or directly
     from a string content.
 
@@ -109,7 +110,9 @@ def load_config(
         raise
 
 
-def parse_config(path: str | None = None, content=None, ctx: os._Environ = os.environ):
+def parse_config(
+    path: Optional[str] = None, content=None, ctx: os._Environ = os.environ
+):
     """Load a yaml configuration file and resolve environment variables in it.
 
     Args:
@@ -185,14 +188,14 @@ def setup_logging():
 
     # Ignore Cloud SDK warning when using a user instead of service account
     try:
-        from google.auth._default import _CLOUD_SDK_CREDENTIALS_WARNING  # noqa: PLC0415
+        from google.auth._default import _CLOUD_SDK_CREDENTIALS_WARNING
 
         warnings.filterwarnings("ignore", message=_CLOUD_SDK_CREDENTIALS_WARNING)
     except ImportError:
         pass
 
 
-def get_human_time(timestamp: int, timezone: str | None = None) -> str:
+def get_human_time(timestamp: int, timezone: Optional[str] = None) -> str:
     """Get human-readable timestamp from UNIX UTC timestamp.
 
     Args:

--- a/slo_generator/utils.py
+++ b/slo_generator/utils.py
@@ -28,7 +28,6 @@ import warnings
 from collections.abc import Mapping
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
 
 import yaml
 from dateutil import tz
@@ -47,7 +46,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 def load_configs(
-    path: str, ctx: os._Environ = os.environ, kind: Optional[str] = None
+    path: str, ctx: os._Environ = os.environ, kind: str | None = None
 ) -> list:
     """Load multiple slo-generator configs from a folder path.
 
@@ -67,8 +66,8 @@ def load_configs(
 
 
 def load_config(
-    path: str, ctx: os._Environ = os.environ, kind: Optional[str] = None
-) -> Optional[dict]:
+    path: str, ctx: os._Environ = os.environ, kind: str | None = None
+) -> dict | None:
     """Load any slo-generator config, from a local path, a GCS URL, or directly
     from a string content.
 
@@ -110,9 +109,7 @@ def load_config(
         raise
 
 
-def parse_config(
-    path: Optional[str] = None, content=None, ctx: os._Environ = os.environ
-):
+def parse_config(path: str | None = None, content=None, ctx: os._Environ = os.environ):
     """Load a yaml configuration file and resolve environment variables in it.
 
     Args:
@@ -188,14 +185,14 @@ def setup_logging():
 
     # Ignore Cloud SDK warning when using a user instead of service account
     try:
-        from google.auth._default import _CLOUD_SDK_CREDENTIALS_WARNING
+        from google.auth._default import _CLOUD_SDK_CREDENTIALS_WARNING  # noqa: PLC0415
 
         warnings.filterwarnings("ignore", message=_CLOUD_SDK_CREDENTIALS_WARNING)
     except ImportError:
         pass
 
 
-def get_human_time(timestamp: int, timezone: Optional[str] = None) -> str:
+def get_human_time(timestamp: int, timezone: str | None = None) -> str:
     """Get human-readable timestamp from UNIX UTC timestamp.
 
     Args:


### PR DESCRIPTION
The Prometheus backend query method does not propagate the timestamp argument passed on from the compute function upstream.

This results in the twin queries used for good/bad ratio method to default to now (see https://github.com/tomoncle/prometheus-http-client/blob/master/prometheus_http_client/prometheus/client.py#L78) **separately**. In some cases, this very slight delay is sufficient to cause inconsistencies in the SLO calculation.

This problem seems related to issues like https://github.com/google/slo-generator/issues/319. The symptoms on my end where exactly the same as https://github.com/google/slo-generator/issues/343, though for a Prometheus backend: we observed random spikes of error counts.

As the `timestamp` argument already existed in the method signature, but was left unused in the code, I assume this is an oversight.

Looking deeper into the code, it turns out that the distribution_cut method did not pass the `timestamp` argument either to the query method. I initially only tested this with the good_bad_ratio method, so the first version of this fix missed this omission as well.